### PR TITLE
auto: #21 Define a transport-neutral RuntimeEvent schema; SSE becomes an adapter

### DIFF
--- a/backend/runtime/events.py
+++ b/backend/runtime/events.py
@@ -1,0 +1,153 @@
+"""Transport-neutral RuntimeEvent schema shared by every runtime stream adapter.
+
+SSE is only one consumer. The typed models here are the source of truth for every
+event that leaves the runtime; the zod mirrors in ``frontend/src/lib/runtime-events.ts``
+must stay in sync with them, and the drift-guard in ``tests/test_runtime_events.py``
+regenerates ``events.schema.json`` on every run so backend and frontend cannot diverge
+silently.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Any, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+
+RUNTIME_EVENT_SCHEMA_VERSION: int = 1
+
+SCHEMA_SNAPSHOT_PATH = Path(__file__).with_name("events.schema.json")
+
+
+class _RuntimeEventBase(BaseModel):
+    """Fields common to every runtime event, regardless of transport."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(
+        default=RUNTIME_EVENT_SCHEMA_VERSION,
+        description="Version of the RuntimeEvent schema this event conforms to.",
+    )
+    request_id: Optional[str] = Field(
+        default=None,
+        description="Stable per-turn identifier stamped by the transport adapter.",
+    )
+    event_index: Optional[int] = Field(
+        default=None,
+        description="Monotonic 1-based sequence number within a single turn.",
+        ge=1,
+    )
+
+
+class RetrievalRuntimeEvent(_RuntimeEventBase):
+    type: Literal["retrieval"] = "retrieval"
+    query: str
+    results: list[dict[str, Any]]
+
+
+class TokenRuntimeEvent(_RuntimeEventBase):
+    type: Literal["token"] = "token"
+    content: str
+
+
+class ToolStartRuntimeEvent(_RuntimeEventBase):
+    type: Literal["tool_start"] = "tool_start"
+    tool: str
+    input: str
+    run_id: str
+
+
+class ToolEndRuntimeEvent(_RuntimeEventBase):
+    type: Literal["tool_end"] = "tool_end"
+    tool: str
+    output: str
+    run_id: str
+    result: Optional[dict[str, Any]] = None
+    policy: Optional[dict[str, Any]] = None
+
+
+class PlanCreatedRuntimeEvent(_RuntimeEventBase):
+    type: Literal["plan_created"] = "plan_created"
+    summary: str
+    plan: dict[str, Any]
+    run_id: Optional[str] = None
+    tool_trace: Optional[list[dict[str, Any]]] = None
+
+
+class PlanUpdatedRuntimeEvent(_RuntimeEventBase):
+    type: Literal["plan_updated"] = "plan_updated"
+    summary: str
+    plan: dict[str, Any]
+    run_id: Optional[str] = None
+    tool_trace: Optional[list[dict[str, Any]]] = None
+
+
+class VerificationResultRuntimeEvent(_RuntimeEventBase):
+    type: Literal["verification_result"] = "verification_result"
+    summary: str
+    verdict: Literal["pass", "repair_required", "fail"]
+    verification: dict[str, Any]
+    run_id: Optional[str] = None
+    tool_trace: Optional[list[dict[str, Any]]] = None
+
+
+class NewResponseRuntimeEvent(_RuntimeEventBase):
+    type: Literal["new_response"] = "new_response"
+
+
+class DoneRuntimeEvent(_RuntimeEventBase):
+    type: Literal["done"] = "done"
+    content: str
+    session_id: Optional[str] = None
+
+
+class ErrorRuntimeEvent(_RuntimeEventBase):
+    type: Literal["error"] = "error"
+    error: str
+
+
+RuntimeEvent = Annotated[
+    Union[
+        RetrievalRuntimeEvent,
+        TokenRuntimeEvent,
+        ToolStartRuntimeEvent,
+        ToolEndRuntimeEvent,
+        PlanCreatedRuntimeEvent,
+        PlanUpdatedRuntimeEvent,
+        VerificationResultRuntimeEvent,
+        NewResponseRuntimeEvent,
+        DoneRuntimeEvent,
+        ErrorRuntimeEvent,
+    ],
+    Field(discriminator="type"),
+]
+
+RUNTIME_EVENT_TYPES: tuple[str, ...] = (
+    "retrieval",
+    "token",
+    "tool_start",
+    "tool_end",
+    "plan_created",
+    "plan_updated",
+    "verification_result",
+    "new_response",
+    "done",
+    "error",
+)
+
+_RUNTIME_EVENT_ADAPTER: TypeAdapter[RuntimeEvent] = TypeAdapter(RuntimeEvent)
+
+
+def build_runtime_event(payload: dict[str, Any]) -> Any:
+    """Validate ``payload`` and return the matching pydantic RuntimeEvent instance."""
+    return _RUNTIME_EVENT_ADAPTER.validate_python(payload)
+
+
+def dump_runtime_event(payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate ``payload`` and return its JSON-mode dict, with ``schema_version`` stamped."""
+    event = _RUNTIME_EVENT_ADAPTER.validate_python(payload)
+    return _RUNTIME_EVENT_ADAPTER.dump_python(event, mode="json", exclude_none=True)
+
+
+def generate_runtime_events_schema() -> dict[str, Any]:
+    """Return the JSON schema describing the RuntimeEvent union."""
+    return _RUNTIME_EVENT_ADAPTER.json_schema(ref_template="#/$defs/{model}")

--- a/backend/runtime/events.schema.json
+++ b/backend/runtime/events.schema.json
@@ -1,0 +1,753 @@
+{
+  "$defs": {
+    "DoneRuntimeEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "title": "Content",
+          "type": "string"
+        },
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "schema_version": {
+          "default": 1,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "session_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Session Id"
+        },
+        "type": {
+          "const": "done",
+          "default": "done",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "title": "DoneRuntimeEvent",
+      "type": "object"
+    },
+    "ErrorRuntimeEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "error": {
+          "title": "Error",
+          "type": "string"
+        },
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "schema_version": {
+          "default": 1,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "type": {
+          "const": "error",
+          "default": "error",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error"
+      ],
+      "title": "ErrorRuntimeEvent",
+      "type": "object"
+    },
+    "NewResponseRuntimeEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "schema_version": {
+          "default": 1,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "type": {
+          "const": "new_response",
+          "default": "new_response",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "title": "NewResponseRuntimeEvent",
+      "type": "object"
+    },
+    "PlanCreatedRuntimeEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "plan": {
+          "additionalProperties": true,
+          "title": "Plan",
+          "type": "object"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "run_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Run Id"
+        },
+        "schema_version": {
+          "default": 1,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        },
+        "tool_trace": {
+          "anyOf": [
+            {
+              "items": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Trace"
+        },
+        "type": {
+          "const": "plan_created",
+          "default": "plan_created",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "plan"
+      ],
+      "title": "PlanCreatedRuntimeEvent",
+      "type": "object"
+    },
+    "PlanUpdatedRuntimeEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "plan": {
+          "additionalProperties": true,
+          "title": "Plan",
+          "type": "object"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "run_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Run Id"
+        },
+        "schema_version": {
+          "default": 1,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        },
+        "tool_trace": {
+          "anyOf": [
+            {
+              "items": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Trace"
+        },
+        "type": {
+          "const": "plan_updated",
+          "default": "plan_updated",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "plan"
+      ],
+      "title": "PlanUpdatedRuntimeEvent",
+      "type": "object"
+    },
+    "RetrievalRuntimeEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "query": {
+          "title": "Query",
+          "type": "string"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "results": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Results",
+          "type": "array"
+        },
+        "schema_version": {
+          "default": 1,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "type": {
+          "const": "retrieval",
+          "default": "retrieval",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "query",
+        "results"
+      ],
+      "title": "RetrievalRuntimeEvent",
+      "type": "object"
+    },
+    "TokenRuntimeEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "title": "Content",
+          "type": "string"
+        },
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "schema_version": {
+          "default": 1,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "type": {
+          "const": "token",
+          "default": "token",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "title": "TokenRuntimeEvent",
+      "type": "object"
+    },
+    "ToolEndRuntimeEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "output": {
+          "title": "Output",
+          "type": "string"
+        },
+        "policy": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Policy"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Result"
+        },
+        "run_id": {
+          "title": "Run Id",
+          "type": "string"
+        },
+        "schema_version": {
+          "default": 1,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "tool": {
+          "title": "Tool",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_end",
+          "default": "tool_end",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool",
+        "output",
+        "run_id"
+      ],
+      "title": "ToolEndRuntimeEvent",
+      "type": "object"
+    },
+    "ToolStartRuntimeEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "input": {
+          "title": "Input",
+          "type": "string"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "run_id": {
+          "title": "Run Id",
+          "type": "string"
+        },
+        "schema_version": {
+          "default": 1,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "tool": {
+          "title": "Tool",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_start",
+          "default": "tool_start",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool",
+        "input",
+        "run_id"
+      ],
+      "title": "ToolStartRuntimeEvent",
+      "type": "object"
+    },
+    "VerificationResultRuntimeEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "run_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Run Id"
+        },
+        "schema_version": {
+          "default": 1,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        },
+        "tool_trace": {
+          "anyOf": [
+            {
+              "items": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Trace"
+        },
+        "type": {
+          "const": "verification_result",
+          "default": "verification_result",
+          "title": "Type",
+          "type": "string"
+        },
+        "verdict": {
+          "enum": [
+            "pass",
+            "repair_required",
+            "fail"
+          ],
+          "title": "Verdict",
+          "type": "string"
+        },
+        "verification": {
+          "additionalProperties": true,
+          "title": "Verification",
+          "type": "object"
+        }
+      },
+      "required": [
+        "summary",
+        "verdict",
+        "verification"
+      ],
+      "title": "VerificationResultRuntimeEvent",
+      "type": "object"
+    }
+  },
+  "discriminator": {
+    "mapping": {
+      "done": "#/$defs/DoneRuntimeEvent",
+      "error": "#/$defs/ErrorRuntimeEvent",
+      "new_response": "#/$defs/NewResponseRuntimeEvent",
+      "plan_created": "#/$defs/PlanCreatedRuntimeEvent",
+      "plan_updated": "#/$defs/PlanUpdatedRuntimeEvent",
+      "retrieval": "#/$defs/RetrievalRuntimeEvent",
+      "token": "#/$defs/TokenRuntimeEvent",
+      "tool_end": "#/$defs/ToolEndRuntimeEvent",
+      "tool_start": "#/$defs/ToolStartRuntimeEvent",
+      "verification_result": "#/$defs/VerificationResultRuntimeEvent"
+    },
+    "propertyName": "type"
+  },
+  "oneOf": [
+    {
+      "$ref": "#/$defs/RetrievalRuntimeEvent"
+    },
+    {
+      "$ref": "#/$defs/TokenRuntimeEvent"
+    },
+    {
+      "$ref": "#/$defs/ToolStartRuntimeEvent"
+    },
+    {
+      "$ref": "#/$defs/ToolEndRuntimeEvent"
+    },
+    {
+      "$ref": "#/$defs/PlanCreatedRuntimeEvent"
+    },
+    {
+      "$ref": "#/$defs/PlanUpdatedRuntimeEvent"
+    },
+    {
+      "$ref": "#/$defs/VerificationResultRuntimeEvent"
+    },
+    {
+      "$ref": "#/$defs/NewResponseRuntimeEvent"
+    },
+    {
+      "$ref": "#/$defs/DoneRuntimeEvent"
+    },
+    {
+      "$ref": "#/$defs/ErrorRuntimeEvent"
+    }
+  ]
+}

--- a/backend/runtime/query_engine.py
+++ b/backend/runtime/query_engine.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, replace
 from typing import Any, AsyncGenerator
 
 from config import get_max_tokens_per_turn, get_verification_settings
+from runtime.events import dump_runtime_event
 from runtime.turn_ledger import TurnLedger, TurnResult
 
 
@@ -444,7 +445,11 @@ class QueryEngine:
             event_index += 1
             envelope.setdefault("request_id", request_id)
             envelope.setdefault("event_index", event_index)
-            return f"data: {json.dumps(envelope, ensure_ascii=False)}\n\n"
+            # Validate + stamp schema_version through the transport-neutral
+            # RuntimeEvent schema so SSE, WebSocket, and any future adapter share
+            # one source of truth for event shapes.
+            validated = dump_runtime_event(envelope)
+            return f"data: {json.dumps(validated, ensure_ascii=False)}\n\n"
 
         turn = QueryTurnInput(
             message=message,

--- a/backend/tests/test_runtime_events.py
+++ b/backend/tests/test_runtime_events.py
@@ -1,0 +1,138 @@
+"""Drift-guard + smoke tests for the transport-neutral RuntimeEvent schema.
+
+Every SSE (and future WebSocket/stdin) payload leaving the runtime is validated
+through the pydantic models in ``runtime.events``. The frontend mirrors them as
+zod schemas — the committed ``runtime/events.schema.json`` snapshot here is the
+contract both sides agree on. This test re-generates the snapshot and fails the
+build on drift.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from runtime.events import (
+    RUNTIME_EVENT_SCHEMA_VERSION,
+    RUNTIME_EVENT_TYPES,
+    SCHEMA_SNAPSHOT_PATH,
+    build_runtime_event,
+    dump_runtime_event,
+    generate_runtime_events_schema,
+)
+
+
+def test_runtime_event_schema_snapshot_matches_pydantic_models() -> None:
+    """Fail the build if the committed JSON schema drifts from pydantic models.
+
+    The frontend zod schemas are regenerated against the committed snapshot;
+    without this guard a silent backend change would leave the frontend parsing
+    the old shape. Regenerate with:
+        python -c "import json; from runtime.events import *; \
+            SCHEMA_SNAPSHOT_PATH.write_text(json.dumps(generate_runtime_events_schema(), indent=2, sort_keys=True) + '\\n')"
+    """
+    committed = json.loads(SCHEMA_SNAPSHOT_PATH.read_text())
+    current = generate_runtime_events_schema()
+    assert current == committed, (
+        "backend/runtime/events.schema.json is out of date with "
+        "runtime.events — regenerate it and update the frontend zod mirror."
+    )
+
+
+def test_runtime_event_snapshot_lists_every_expected_event_type() -> None:
+    committed = json.loads(SCHEMA_SNAPSHOT_PATH.read_text())
+    discriminator_mapping = committed["discriminator"]["mapping"]
+    assert set(discriminator_mapping.keys()) == set(RUNTIME_EVENT_TYPES)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"type": "retrieval", "query": "brca1", "results": [{"text": "x", "source": "a", "score": 0.1}]},
+        {"type": "token", "content": "hello"},
+        {"type": "tool_start", "tool": "read_file", "input": "x", "run_id": "run-1"},
+        {
+            "type": "tool_end",
+            "tool": "read_file",
+            "output": "x",
+            "run_id": "run-1",
+            "result": {"status": "success"},
+        },
+        {
+            "type": "plan_created",
+            "summary": "planner",
+            "plan": {"goal": "g", "steps": []},
+        },
+        {
+            "type": "plan_updated",
+            "summary": "planner",
+            "plan": {"goal": "g", "steps": []},
+        },
+        {
+            "type": "verification_result",
+            "summary": "ok",
+            "verdict": "pass",
+            "verification": {"verdict": "pass"},
+        },
+        {"type": "new_response"},
+        {"type": "done", "content": "final"},
+        {"type": "error", "error": "boom"},
+    ],
+)
+def test_build_runtime_event_accepts_each_event_type(payload: dict) -> None:
+    event = build_runtime_event(payload)
+    assert event.type == payload["type"]
+    assert event.schema_version == RUNTIME_EVENT_SCHEMA_VERSION
+
+
+def test_dump_runtime_event_stamps_schema_version_and_drops_nones() -> None:
+    dumped = dump_runtime_event({"type": "token", "content": "hello"})
+    assert dumped == {
+        "type": "token",
+        "content": "hello",
+        "schema_version": RUNTIME_EVENT_SCHEMA_VERSION,
+    }
+
+
+def test_dump_runtime_event_preserves_transport_envelope_fields() -> None:
+    dumped = dump_runtime_event(
+        {
+            "type": "token",
+            "content": "hello",
+            "request_id": "req-1",
+            "event_index": 7,
+        }
+    )
+    assert dumped["request_id"] == "req-1"
+    assert dumped["event_index"] == 7
+    assert dumped["schema_version"] == RUNTIME_EVENT_SCHEMA_VERSION
+
+
+def test_build_runtime_event_rejects_unknown_event_type() -> None:
+    with pytest.raises(ValidationError):
+        build_runtime_event({"type": "not_a_type", "content": "x"})
+
+
+def test_build_runtime_event_rejects_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        build_runtime_event({"type": "token", "content": "hi", "surprise": True})
+
+
+def test_build_runtime_event_rejects_bad_verdict() -> None:
+    with pytest.raises(ValidationError):
+        build_runtime_event(
+            {
+                "type": "verification_result",
+                "summary": "x",
+                "verdict": "maybe",
+                "verification": {},
+            }
+        )
+
+
+def test_schema_snapshot_path_points_inside_backend_runtime() -> None:
+    assert SCHEMA_SNAPSHOT_PATH.parent.name == "runtime"
+    assert SCHEMA_SNAPSHOT_PATH.name == "events.schema.json"
+    assert SCHEMA_SNAPSHOT_PATH.exists()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,8 @@
         "react-markdown": "^9.0.0",
         "rehype-highlight": "^7.0.0",
         "remark-gfm": "^4.0.0",
-        "tailwind-merge": "^2.3.0"
+        "tailwind-merge": "^2.3.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -7192,6 +7193,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9678,6 +9680,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,8 @@
     "react-markdown": "^9.0.0",
     "rehype-highlight": "^7.0.0",
     "remark-gfm": "^4.0.0",
-    "tailwind-merge": "^2.3.0"
+    "tailwind-merge": "^2.3.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/frontend/src/lib/api.stream-chat.test.ts
+++ b/frontend/src/lib/api.stream-chat.test.ts
@@ -80,6 +80,7 @@ describe("streamChat", () => {
     const toolEnds: string[] = [];
     const planSummaries: string[] = [];
     const verificationVerdicts: string[] = [];
+    const parseErrors: string[] = [];
     let sawNewResponse = false;
     let finalContent = "";
     let finalRequestId = "";
@@ -129,6 +130,9 @@ describe("streamChat", () => {
         onError: (error) => {
           throw new Error(`unexpected stream error: ${error}`);
         },
+        onParseError: (event) => {
+          parseErrors.push(event.error);
+        },
       }
     );
 
@@ -144,8 +148,11 @@ describe("streamChat", () => {
     expect(sawNewResponse).toBe(true);
     expect(finalContent).toBe("BioAPEX complete.");
     expect(finalRequestId).toBe("request-1");
+    expect(parseErrors).toHaveLength(1);
+    expect(parseErrors[0]).toMatch(/JSON|runtime event/i);
     expect(eventTypes).toEqual([
       "retrieval",
+      "parse_error",
       "token",
       "tool_start",
       "tool_end",
@@ -184,6 +191,7 @@ describe("streamChat", () => {
 
     const eventTypes: string[] = [];
     const eventIndices: number[] = [];
+    const parseErrors: string[] = [];
     let surfacedError = "";
     let surfacedRequestId = "";
 
@@ -219,11 +227,15 @@ describe("streamChat", () => {
           surfacedError = error;
           surfacedRequestId = requestId ?? "";
         },
+        onParseError: (event) => {
+          parseErrors.push(event.error);
+        },
       }
     );
 
-    expect(eventTypes).toEqual(["error"]);
+    expect(eventTypes).toEqual(["parse_error", "error"]);
     expect(eventIndices).toEqual([1]);
+    expect(parseErrors).toHaveLength(1);
     expect(surfacedError).toBe("executor boom");
     expect(surfacedRequestId).toBe("request-2");
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,6 +2,7 @@ import type {
   AccessProbeResponse,
   ChatStreamEvent,
   ChatStreamErrorEvent,
+  ChatStreamParseErrorEvent,
   ChatStreamPlanCreatedEvent,
   ChatStreamPlanUpdatedEvent,
   ChatStreamVerificationResultEvent,
@@ -1081,6 +1082,11 @@ export interface StreamCallbacks {
   onNewResponse?: () => void;
   onDone?: (content: string, requestId?: string) => void;
   onError?: (error: string, requestId?: string) => void;
+  /**
+   * Called when an incoming SSE payload fails RuntimeEvent validation. The
+   * stream keeps running — malformed events are surfaced, not terminal.
+   */
+  onParseError?: (event: ChatStreamParseErrorEvent) => void;
 }
 
 export async function streamChat(
@@ -1164,6 +1170,9 @@ export async function streamChat(
         break;
       case "error":
         callbacks.onError?.(event.error, event.request_id);
+        break;
+      case "parse_error":
+        callbacks.onParseError?.(event);
         break;
     }
   };

--- a/frontend/src/lib/chat-stream-events.ts
+++ b/frontend/src/lib/chat-stream-events.ts
@@ -1,15 +1,7 @@
+import { parseRuntimeEvent } from "./runtime-events";
 import type {
-  ChatStreamDoneEvent,
-  ChatStreamErrorEvent,
   ChatStreamEvent,
-  ChatStreamNewResponseEvent,
-  ChatStreamPlanCreatedEvent,
-  ChatStreamPlanUpdatedEvent,
-  ChatStreamRetrievalEvent,
-  ChatStreamTokenEvent,
-  ChatStreamToolEndEvent,
-  ChatStreamToolStartEvent,
-  ChatStreamVerificationResultEvent,
+  ChatStreamParseErrorEvent,
   JsonObject,
   RetrievalResult,
   ToolResultEnvelope,
@@ -24,16 +16,6 @@ interface ParseChatStreamChunkOptions {
   flush?: boolean;
 }
 
-type UnknownRecord = Record<string, unknown>;
-
-function isObjectRecord(value: unknown): value is UnknownRecord {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function readString(value: unknown): string | null {
-  return typeof value === "string" ? value : null;
-}
-
 function readOptionalString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
@@ -45,289 +27,129 @@ function readOptionalEventIndex(value: unknown): number | undefined {
   return value;
 }
 
-function readObject(value: unknown): JsonObject | null {
-  return isObjectRecord(value) ? (value as JsonObject) : null;
-}
-
-function readObjectArray(value: unknown): JsonObject[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
+/**
+ * Route an already-decoded payload through the RuntimeEvent zod schema and
+ * shape the result into the `ChatStreamEvent` union the app already consumes.
+ *
+ * Malformed payloads become a synthetic `parse_error` stream event so the app
+ * can surface the failure instead of silently dropping it — that matches the
+ * issue-21 acceptance criterion.
+ */
+export function parseChatStreamEventPayload(payload: unknown): ChatStreamEvent {
+  const parsed = parseRuntimeEvent(payload);
+  if (!parsed.ok) {
+    return buildParseErrorEvent(parsed.error, payload);
   }
 
-  const objects = value.filter(isObjectRecord);
-  return objects.length === value.length ? (objects as JsonObject[]) : undefined;
-}
-
-function readRetrievalResult(value: unknown): RetrievalResult | null {
-  if (!isObjectRecord(value)) {
-    return null;
-  }
-
-  const text = readString(value.text);
-  const source = readString(value.source);
-  const score = typeof value.score === "number" ? value.score : null;
-  if (text === null || source === null || score === null || Number.isNaN(score)) {
-    return null;
-  }
-
-  const result: RetrievalResult = { text, source, score };
-  const memoryType = readOptionalString(value.memory_type);
-  const memoryTypeLabel = readOptionalString(value.memory_type_label);
-  const memoryName = readOptionalString(value.memory_name);
-  const memoryDescription = readOptionalString(value.memory_description);
-
-  if (memoryType !== undefined) {
-    result.memory_type = memoryType;
-  }
-  if (memoryTypeLabel !== undefined) {
-    result.memory_type_label = memoryTypeLabel;
-  }
-  if (memoryName !== undefined) {
-    result.memory_name = memoryName;
-  }
-  if (memoryDescription !== undefined) {
-    result.memory_description = memoryDescription;
-  }
-
-  return result;
-}
-
-function readRetrievalResults(value: unknown): RetrievalResult[] | null {
-  if (!Array.isArray(value)) {
-    return null;
-  }
-
-  const results = value.map(readRetrievalResult);
-  return results.every((result): result is RetrievalResult => result !== null)
-    ? results
-    : null;
-}
-
-function readToolResultEnvelope(value: unknown): ToolResultEnvelope | undefined {
-  return isObjectRecord(value) ? (value as unknown as ToolResultEnvelope) : undefined;
-}
-
-function parseRetrievalEvent(
-  payload: UnknownRecord,
-  requestId: string | undefined,
-  eventIndex: number | undefined
-): ChatStreamRetrievalEvent | null {
-  const query = readString(payload.query);
-  const results = readRetrievalResults(payload.results);
-  if (query === null || results === null) {
-    return null;
-  }
-  return {
-    type: "retrieval",
-    query,
-    results,
+  const event = parsed.event;
+  const requestId = readOptionalString(event.request_id);
+  const eventIndex = readOptionalEventIndex(event.event_index);
+  const base = {
     request_id: requestId,
     event_index: eventIndex,
   };
-}
 
-function parseTokenEvent(
-  payload: UnknownRecord,
-  requestId: string | undefined,
-  eventIndex: number | undefined
-): ChatStreamTokenEvent | null {
-  const content = readString(payload.content);
-  if (content === null) {
-    return null;
-  }
-  return {
-    type: "token",
-    content,
-    request_id: requestId,
-    event_index: eventIndex,
-  };
-}
-
-function parseToolStartEvent(
-  payload: UnknownRecord,
-  requestId: string | undefined,
-  eventIndex: number | undefined
-): ChatStreamToolStartEvent | null {
-  const tool = readString(payload.tool);
-  const input = readString(payload.input);
-  if (tool === null || input === null) {
-    return null;
-  }
-  return {
-    type: "tool_start",
-    tool,
-    input,
-    run_id: readOptionalString(payload.run_id),
-    request_id: requestId,
-    event_index: eventIndex,
-  };
-}
-
-function parseToolEndEvent(
-  payload: UnknownRecord,
-  requestId: string | undefined,
-  eventIndex: number | undefined
-): ChatStreamToolEndEvent | null {
-  const tool = readString(payload.tool);
-  const output = readString(payload.output);
-  if (tool === null || output === null) {
-    return null;
-  }
-  return {
-    type: "tool_end",
-    tool,
-    output,
-    run_id: readOptionalString(payload.run_id),
-    result: readToolResultEnvelope(payload.result),
-    policy: readObject(payload.policy) ?? undefined,
-    request_id: requestId,
-    event_index: eventIndex,
-  };
-}
-
-function parsePlanCreatedEvent(
-  payload: UnknownRecord,
-  requestId: string | undefined,
-  eventIndex: number | undefined
-): ChatStreamPlanCreatedEvent | null {
-  const summary = readString(payload.summary);
-  const plan = readObject(payload.plan);
-  if (summary === null || plan === null) {
-    return null;
-  }
-  return {
-    type: "plan_created",
-    summary,
-    plan,
-    run_id: readOptionalString(payload.run_id),
-    tool_trace: readObjectArray(payload.tool_trace),
-    request_id: requestId,
-    event_index: eventIndex,
-  };
-}
-
-function parsePlanUpdatedEvent(
-  payload: UnknownRecord,
-  requestId: string | undefined,
-  eventIndex: number | undefined
-): ChatStreamPlanUpdatedEvent | null {
-  const summary = readString(payload.summary);
-  const plan = readObject(payload.plan);
-  if (summary === null || plan === null) {
-    return null;
-  }
-  return {
-    type: "plan_updated",
-    summary,
-    plan,
-    run_id: readOptionalString(payload.run_id),
-    tool_trace: readObjectArray(payload.tool_trace),
-    request_id: requestId,
-    event_index: eventIndex,
-  };
-}
-
-function parseVerificationResultEvent(
-  payload: UnknownRecord,
-  requestId: string | undefined,
-  eventIndex: number | undefined
-): ChatStreamVerificationResultEvent | null {
-  const summary = readString(payload.summary);
-  const verdict = readString(payload.verdict);
-  const verification = readObject(payload.verification);
-  if (
-    summary === null ||
-    verification === null ||
-    (verdict !== "pass" && verdict !== "repair_required" && verdict !== "fail")
-  ) {
-    return null;
-  }
-  return {
-    type: "verification_result",
-    summary,
-    verdict,
-    verification,
-    run_id: readOptionalString(payload.run_id),
-    tool_trace: readObjectArray(payload.tool_trace),
-    request_id: requestId,
-    event_index: eventIndex,
-  };
-}
-
-function parseNewResponseEvent(
-  requestId: string | undefined,
-  eventIndex: number | undefined
-): ChatStreamNewResponseEvent {
-  return {
-    type: "new_response",
-    request_id: requestId,
-    event_index: eventIndex,
-  };
-}
-
-function parseDoneEvent(
-  payload: UnknownRecord,
-  requestId: string | undefined,
-  eventIndex: number | undefined
-): ChatStreamDoneEvent {
-  return {
-    type: "done",
-    content: readString(payload.content) ?? "",
-    session_id: readOptionalString(payload.session_id),
-    request_id: requestId,
-    event_index: eventIndex,
-  };
-}
-
-function parseErrorEvent(
-  payload: UnknownRecord,
-  requestId: string | undefined,
-  eventIndex: number | undefined
-): ChatStreamErrorEvent {
-  return {
-    type: "error",
-    error: readString(payload.error) ?? "Unknown error",
-    request_id: requestId,
-    event_index: eventIndex,
-  };
-}
-
-export function parseChatStreamEventPayload(payload: unknown): ChatStreamEvent | null {
-  if (!isObjectRecord(payload)) {
-    return null;
-  }
-
-  const eventType = readString(payload.type);
-  const requestId = readOptionalString(payload.request_id);
-  const eventIndex = readOptionalEventIndex(payload.event_index);
-  if (eventType === null) {
-    return null;
-  }
-
-  switch (eventType) {
+  switch (event.type) {
     case "retrieval":
-      return parseRetrievalEvent(payload, requestId, eventIndex);
+      return {
+        type: "retrieval",
+        query: event.query,
+        results: event.results as unknown as RetrievalResult[],
+        ...base,
+      };
     case "token":
-      return parseTokenEvent(payload, requestId, eventIndex);
+      return {
+        type: "token",
+        content: event.content,
+        ...base,
+      };
     case "tool_start":
-      return parseToolStartEvent(payload, requestId, eventIndex);
+      return {
+        type: "tool_start",
+        tool: event.tool,
+        input: event.input,
+        run_id: event.run_id,
+        ...base,
+      };
     case "tool_end":
-      return parseToolEndEvent(payload, requestId, eventIndex);
+      return {
+        type: "tool_end",
+        tool: event.tool,
+        output: event.output,
+        run_id: event.run_id,
+        result: (event.result ?? undefined) as ToolResultEnvelope | undefined,
+        policy: (event.policy ?? undefined) as JsonObject | undefined,
+        ...base,
+      };
     case "plan_created":
-      return parsePlanCreatedEvent(payload, requestId, eventIndex);
+      return {
+        type: "plan_created",
+        summary: event.summary,
+        plan: event.plan as JsonObject,
+        run_id: event.run_id ?? undefined,
+        tool_trace: (event.tool_trace ?? undefined) as JsonObject[] | undefined,
+        ...base,
+      };
     case "plan_updated":
-      return parsePlanUpdatedEvent(payload, requestId, eventIndex);
+      return {
+        type: "plan_updated",
+        summary: event.summary,
+        plan: event.plan as JsonObject,
+        run_id: event.run_id ?? undefined,
+        tool_trace: (event.tool_trace ?? undefined) as JsonObject[] | undefined,
+        ...base,
+      };
     case "verification_result":
-      return parseVerificationResultEvent(payload, requestId, eventIndex);
+      return {
+        type: "verification_result",
+        summary: event.summary,
+        verdict: event.verdict,
+        verification: event.verification as JsonObject,
+        run_id: event.run_id ?? undefined,
+        tool_trace: (event.tool_trace ?? undefined) as JsonObject[] | undefined,
+        ...base,
+      };
     case "new_response":
-      return parseNewResponseEvent(requestId, eventIndex);
+      return { type: "new_response", ...base };
     case "done":
-      return parseDoneEvent(payload, requestId, eventIndex);
+      return {
+        type: "done",
+        content: event.content,
+        session_id: event.session_id ?? undefined,
+        ...base,
+      };
     case "error":
-      return parseErrorEvent(payload, requestId, eventIndex);
-    default:
-      return null;
+      return {
+        type: "error",
+        error: event.error,
+        ...base,
+      };
   }
+}
+
+function buildParseErrorEvent(
+  message: string,
+  payload: unknown
+): ChatStreamParseErrorEvent {
+  const envelope =
+    typeof payload === "object" && payload !== null
+      ? (payload as Record<string, unknown>)
+      : undefined;
+  const event: ChatStreamParseErrorEvent = {
+    type: "parse_error",
+    error: message,
+    request_id: readOptionalString(envelope?.request_id),
+    event_index: readOptionalEventIndex(envelope?.event_index),
+  };
+  try {
+    const raw = JSON.stringify(payload);
+    if (typeof raw === "string") {
+      event.raw = raw.length > 2000 ? `${raw.slice(0, 2000)}…` : raw;
+    }
+  } catch {
+    // payload had a cycle or BigInt — omit raw.
+  }
+  return event;
 }
 
 export function parseChatStreamChunk(
@@ -351,15 +173,19 @@ export function parseChatStreamChunk(
         continue;
       }
 
+      const dataLine = line.slice(6);
+      let parsed: unknown;
       try {
-        const parsed = JSON.parse(line.slice(6));
-        const event = parseChatStreamEventPayload(parsed);
-        if (event) {
-          events.push(event);
-        }
+        parsed = JSON.parse(dataLine);
       } catch {
+        events.push({
+          type: "parse_error",
+          error: "SSE chunk was not valid JSON.",
+          raw: dataLine.length > 2000 ? `${dataLine.slice(0, 2000)}…` : dataLine,
+        });
         continue;
       }
+      events.push(parseChatStreamEventPayload(parsed));
     }
   }
 

--- a/frontend/src/lib/chat-stream-reducer.ts
+++ b/frontend/src/lib/chat-stream-reducer.ts
@@ -147,6 +147,15 @@ export function applyStreamEvent(
       return reduceDoneEvent(state, event, options.now);
     case "error":
       return reduceErrorEvent(state, event, options.now);
+    case "parse_error":
+      // Parse errors are surfaced through onParseError but should not mutate
+      // the message tree or end the stream — a single malformed SSE payload
+      // must not corrupt an otherwise healthy turn.
+      return {
+        messages: state.messages,
+        streamingMessageId: state.streamingMessageId,
+        finished: false,
+      };
   }
 }
 

--- a/frontend/src/lib/runtime-events.test.ts
+++ b/frontend/src/lib/runtime-events.test.ts
@@ -1,0 +1,180 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  parseRuntimeEvent,
+  RUNTIME_EVENT_SCHEMAS,
+  RUNTIME_EVENT_TYPES,
+  RUNTIME_EVENT_SCHEMA_VERSION,
+} from "./runtime-events";
+
+interface BackendPropertySchema {
+  default?: unknown;
+  anyOf?: unknown;
+}
+
+interface BackendDefSchema {
+  additionalProperties?: boolean;
+  properties: Record<string, BackendPropertySchema>;
+  required?: string[];
+}
+
+interface BackendSchema {
+  $defs: Record<string, BackendDefSchema>;
+  discriminator: { propertyName: string; mapping: Record<string, string> };
+  oneOf: Array<{ $ref: string }>;
+}
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = path.resolve(
+  HERE,
+  "../../../backend/runtime/events.schema.json"
+);
+
+function loadBackendSchema(): BackendSchema {
+  const raw = readFileSync(SCHEMA_PATH, "utf-8");
+  return JSON.parse(raw) as BackendSchema;
+}
+
+function minimalPayloadFor(eventType: string): Record<string, unknown> {
+  switch (eventType) {
+    case "retrieval":
+      return { type: "retrieval", query: "q", results: [] };
+    case "token":
+      return { type: "token", content: "hello" };
+    case "tool_start":
+      return {
+        type: "tool_start",
+        tool: "read_file",
+        input: "memory/MEMORY.md",
+        run_id: "run-1",
+      };
+    case "tool_end":
+      return {
+        type: "tool_end",
+        tool: "read_file",
+        output: "ok",
+        run_id: "run-1",
+      };
+    case "plan_created":
+      return {
+        type: "plan_created",
+        summary: "planned",
+        plan: { steps: [] },
+      };
+    case "plan_updated":
+      return {
+        type: "plan_updated",
+        summary: "refined",
+        plan: { steps: [] },
+      };
+    case "verification_result":
+      return {
+        type: "verification_result",
+        summary: "looks good",
+        verdict: "pass",
+        verification: { verdict: "pass" },
+      };
+    case "new_response":
+      return { type: "new_response" };
+    case "done":
+      return { type: "done", content: "final answer" };
+    case "error":
+      return { type: "error", error: "boom" };
+    default:
+      throw new Error(`No minimal payload defined for ${eventType}`);
+  }
+}
+
+describe("runtime-events zod schemas", () => {
+  it("covers every event type listed in the backend JSON schema snapshot", () => {
+    const backend = loadBackendSchema();
+    const backendTypes = Object.keys(backend.discriminator.mapping).sort();
+    const frontendTypes = [...RUNTIME_EVENT_TYPES].sort();
+    expect(frontendTypes).toEqual(backendTypes);
+  });
+
+  it.each(RUNTIME_EVENT_TYPES)(
+    "accepts a minimal valid payload for %s",
+    (eventType) => {
+      const payload = minimalPayloadFor(eventType);
+      const result = parseRuntimeEvent(payload);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.event.type).toBe(eventType);
+        expect(result.event.schema_version).toBe(RUNTIME_EVENT_SCHEMA_VERSION);
+      }
+    }
+  );
+
+  it.each(RUNTIME_EVENT_TYPES)(
+    "rejects unknown fields on %s (strict mode mirrors pydantic extra='forbid')",
+    (eventType) => {
+      const payload = {
+        ...minimalPayloadFor(eventType),
+        mystery: "should be rejected",
+      };
+      const result = parseRuntimeEvent(payload);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(/mystery|Unrecognized/i);
+      }
+    }
+  );
+
+  it("matches backend required-field expectations for every event type", () => {
+    const backend = loadBackendSchema();
+    for (const eventType of RUNTIME_EVENT_TYPES) {
+      const defName = backend.discriminator.mapping[eventType]?.split("/").pop();
+      expect(defName).toBeDefined();
+      const def = backend.$defs[defName!];
+      expect(def).toBeDefined();
+      const required = def.required ?? [];
+      for (const field of required) {
+        const broken: Record<string, unknown> = {
+          ...minimalPayloadFor(eventType),
+        };
+        delete broken[field];
+        const result = parseRuntimeEvent(broken);
+        expect(
+          result.ok,
+          `${eventType} should reject payloads missing required field ${field}`
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("accepts transport envelope fields (request_id, event_index)", () => {
+    const payload = {
+      type: "token" as const,
+      content: "hi",
+      request_id: "req-1",
+      event_index: 3,
+      schema_version: RUNTIME_EVENT_SCHEMA_VERSION,
+    };
+    const result = parseRuntimeEvent(payload);
+    expect(result.ok).toBe(true);
+    if (result.ok && result.event.type === "token") {
+      expect(result.event.request_id).toBe("req-1");
+      expect(result.event.event_index).toBe(3);
+    }
+  });
+
+  it("returns a parse error for wholly malformed payloads", () => {
+    const result = parseRuntimeEvent({ type: "nonexistent", foo: "bar" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("exposes a zod schema for every runtime event type", () => {
+    for (const eventType of RUNTIME_EVENT_TYPES) {
+      const schema = RUNTIME_EVENT_SCHEMAS[eventType];
+      expect(schema, `${eventType} has a zod schema`).toBeDefined();
+      const parsed = schema.safeParse(minimalPayloadFor(eventType));
+      expect(parsed.success).toBe(true);
+    }
+  });
+});

--- a/frontend/src/lib/runtime-events.ts
+++ b/frontend/src/lib/runtime-events.ts
@@ -1,0 +1,233 @@
+/**
+ * Transport-neutral RuntimeEvent schema — frontend zod mirror.
+ *
+ * Keep this file in sync with `backend/runtime/events.py`. The drift-guard in
+ * `backend/tests/test_runtime_events.py` regenerates the shared JSON schema on
+ * every run; the vitest `runtime-events.test.ts` asserts the zod shapes here
+ * enforce the same required fields, so both sides fail fast when one side
+ * moves without the other.
+ *
+ * SSE is the current adapter in `api.ts`, but any stdin/WebSocket consumer can
+ * reuse `parseRuntimeEvent` to validate an incoming payload.
+ */
+import { z } from "zod";
+
+export const RUNTIME_EVENT_SCHEMA_VERSION = 1 as const;
+
+export const RUNTIME_EVENT_TYPES = [
+  "retrieval",
+  "token",
+  "tool_start",
+  "tool_end",
+  "plan_created",
+  "plan_updated",
+  "verification_result",
+  "new_response",
+  "done",
+  "error",
+] as const;
+
+export type RuntimeEventType = (typeof RUNTIME_EVENT_TYPES)[number];
+
+// Missing schema_version defaults to the current schema so the zod consumer can
+// accept legacy SSE payloads during a backend rollout without silently losing
+// events. Unknown-value cases (e.g., a future schema_version=2 payload hitting
+// a v1 client) still flow through validation and can be gated downstream.
+const schemaVersionField = z
+  .number()
+  .int()
+  .optional()
+  .default(RUNTIME_EVENT_SCHEMA_VERSION);
+
+const requestIdField = z.string().nullish();
+const eventIndexField = z.number().int().min(1).nullish();
+
+const jsonObjectSchema = z
+  .record(z.string(), z.unknown())
+  .readonly()
+  .or(z.record(z.string(), z.unknown()));
+
+const RetrievalResultSchema = z
+  .object({})
+  .catchall(z.unknown());
+
+const RetrievalRuntimeEventSchema = z
+  .object({
+    type: z.literal("retrieval"),
+    schema_version: schemaVersionField,
+    request_id: requestIdField,
+    event_index: eventIndexField,
+    query: z.string(),
+    results: z.array(RetrievalResultSchema),
+  })
+  .strict();
+
+const TokenRuntimeEventSchema = z
+  .object({
+    type: z.literal("token"),
+    schema_version: schemaVersionField,
+    request_id: requestIdField,
+    event_index: eventIndexField,
+    content: z.string(),
+  })
+  .strict();
+
+const ToolStartRuntimeEventSchema = z
+  .object({
+    type: z.literal("tool_start"),
+    schema_version: schemaVersionField,
+    request_id: requestIdField,
+    event_index: eventIndexField,
+    tool: z.string(),
+    input: z.string(),
+    run_id: z.string(),
+  })
+  .strict();
+
+const ToolEndRuntimeEventSchema = z
+  .object({
+    type: z.literal("tool_end"),
+    schema_version: schemaVersionField,
+    request_id: requestIdField,
+    event_index: eventIndexField,
+    tool: z.string(),
+    output: z.string(),
+    run_id: z.string(),
+    result: jsonObjectSchema.nullish(),
+    policy: jsonObjectSchema.nullish(),
+  })
+  .strict();
+
+const PlanCreatedRuntimeEventSchema = z
+  .object({
+    type: z.literal("plan_created"),
+    schema_version: schemaVersionField,
+    request_id: requestIdField,
+    event_index: eventIndexField,
+    summary: z.string(),
+    plan: jsonObjectSchema,
+    run_id: z.string().nullish(),
+    tool_trace: z.array(jsonObjectSchema).nullish(),
+  })
+  .strict();
+
+const PlanUpdatedRuntimeEventSchema = z
+  .object({
+    type: z.literal("plan_updated"),
+    schema_version: schemaVersionField,
+    request_id: requestIdField,
+    event_index: eventIndexField,
+    summary: z.string(),
+    plan: jsonObjectSchema,
+    run_id: z.string().nullish(),
+    tool_trace: z.array(jsonObjectSchema).nullish(),
+  })
+  .strict();
+
+const VerificationResultRuntimeEventSchema = z
+  .object({
+    type: z.literal("verification_result"),
+    schema_version: schemaVersionField,
+    request_id: requestIdField,
+    event_index: eventIndexField,
+    summary: z.string(),
+    verdict: z.enum(["pass", "repair_required", "fail"]),
+    verification: jsonObjectSchema,
+    run_id: z.string().nullish(),
+    tool_trace: z.array(jsonObjectSchema).nullish(),
+  })
+  .strict();
+
+const NewResponseRuntimeEventSchema = z
+  .object({
+    type: z.literal("new_response"),
+    schema_version: schemaVersionField,
+    request_id: requestIdField,
+    event_index: eventIndexField,
+  })
+  .strict();
+
+const DoneRuntimeEventSchema = z
+  .object({
+    type: z.literal("done"),
+    schema_version: schemaVersionField,
+    request_id: requestIdField,
+    event_index: eventIndexField,
+    content: z.string(),
+    session_id: z.string().nullish(),
+  })
+  .strict();
+
+const ErrorRuntimeEventSchema = z
+  .object({
+    type: z.literal("error"),
+    schema_version: schemaVersionField,
+    request_id: requestIdField,
+    event_index: eventIndexField,
+    error: z.string(),
+  })
+  .strict();
+
+export const RuntimeEventSchema = z.discriminatedUnion("type", [
+  RetrievalRuntimeEventSchema,
+  TokenRuntimeEventSchema,
+  ToolStartRuntimeEventSchema,
+  ToolEndRuntimeEventSchema,
+  PlanCreatedRuntimeEventSchema,
+  PlanUpdatedRuntimeEventSchema,
+  VerificationResultRuntimeEventSchema,
+  NewResponseRuntimeEventSchema,
+  DoneRuntimeEventSchema,
+  ErrorRuntimeEventSchema,
+]);
+
+export type RuntimeEvent = z.infer<typeof RuntimeEventSchema>;
+
+export const RUNTIME_EVENT_SCHEMAS: Record<
+  RuntimeEventType,
+  z.ZodTypeAny
+> = {
+  retrieval: RetrievalRuntimeEventSchema,
+  token: TokenRuntimeEventSchema,
+  tool_start: ToolStartRuntimeEventSchema,
+  tool_end: ToolEndRuntimeEventSchema,
+  plan_created: PlanCreatedRuntimeEventSchema,
+  plan_updated: PlanUpdatedRuntimeEventSchema,
+  verification_result: VerificationResultRuntimeEventSchema,
+  new_response: NewResponseRuntimeEventSchema,
+  done: DoneRuntimeEventSchema,
+  error: ErrorRuntimeEventSchema,
+};
+
+export type RuntimeEventParseSuccess = {
+  ok: true;
+  event: RuntimeEvent;
+};
+
+export type RuntimeEventParseFailure = {
+  ok: false;
+  error: string;
+};
+
+export type RuntimeEventParseResult =
+  | RuntimeEventParseSuccess
+  | RuntimeEventParseFailure;
+
+export function parseRuntimeEvent(payload: unknown): RuntimeEventParseResult {
+  const result = RuntimeEventSchema.safeParse(payload);
+  if (result.success) {
+    return { ok: true, event: result.data };
+  }
+
+  const issues = result.error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      return `${path}: ${issue.message}`;
+    })
+    .join("; ");
+
+  return {
+    ok: false,
+    error: issues || "Malformed runtime event payload.",
+  };
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -326,6 +326,16 @@ export interface ChatStreamErrorEvent extends ChatStreamEventBase {
   error: string;
 }
 
+/**
+ * Client-side synthetic event surfaced when an incoming SSE payload fails
+ * RuntimeEvent (zod) validation. Never emitted by the backend.
+ */
+export interface ChatStreamParseErrorEvent extends ChatStreamEventBase {
+  type: "parse_error";
+  error: string;
+  raw?: string;
+}
+
 export type ChatStreamEvent =
   | ChatStreamRetrievalEvent
   | ChatStreamTokenEvent
@@ -336,7 +346,8 @@ export type ChatStreamEvent =
   | ChatStreamVerificationResultEvent
   | ChatStreamNewResponseEvent
   | ChatStreamDoneEvent
-  | ChatStreamErrorEvent;
+  | ChatStreamErrorEvent
+  | ChatStreamParseErrorEvent;
 
 export type ChatStreamEventType = ChatStreamEvent["type"];
 


### PR DESCRIPTION
Closes #21

Opened by the personal automation loop. Draft until human-reviewed.