### PR TITLE
Add CompactionRuntimeEvent for conversation history compression

### DIFF
--- a/backend/runtime/events.py
+++ b/backend/runtime/events.py
@@ -94,6 +94,14 @@ class NewResponseRuntimeEvent(_RuntimeEventBase):
     type: Literal["new_response"] = "new_response"
 
 
+class CompactionRuntimeEvent(_RuntimeEventBase):
+    type: Literal["compaction_event"] = "compaction_event"
+    from_turn: int
+    to_turn: int
+    summary: str
+    saved_tokens: int
+
+
 class DoneRuntimeEvent(_RuntimeEventBase):
     type: Literal["done"] = "done"
     content: str
@@ -115,6 +123,7 @@ RuntimeEvent = Annotated[
         PlanUpdatedRuntimeEvent,
         VerificationResultRuntimeEvent,
         NewResponseRuntimeEvent,
+        CompactionRuntimeEvent,
         DoneRuntimeEvent,
         ErrorRuntimeEvent,
     ],
@@ -130,6 +139,7 @@ RUNTIME_EVENT_TYPES: tuple[str, ...] = (
     "plan_updated",
     "verification_result",
     "new_response",
+    "compaction_event",
     "done",
     "error",
 )

--- a/backend/runtime/events.schema.json
+++ b/backend/runtime/events.schema.json
@@ -1,5 +1,73 @@
 {
   "$defs": {
+    "CompactionRuntimeEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "from_turn": {
+          "title": "From Turn",
+          "type": "integer"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "saved_tokens": {
+          "title": "Saved Tokens",
+          "type": "integer"
+        },
+        "schema_version": {
+          "default": 1,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        },
+        "to_turn": {
+          "title": "To Turn",
+          "type": "integer"
+        },
+        "type": {
+          "const": "compaction_event",
+          "default": "compaction_event",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "from_turn",
+        "to_turn",
+        "summary",
+        "saved_tokens"
+      ],
+      "title": "CompactionRuntimeEvent",
+      "type": "object"
+    },
     "DoneRuntimeEvent": {
       "additionalProperties": false,
       "properties": {
@@ -705,6 +773,7 @@
   },
   "discriminator": {
     "mapping": {
+      "compaction_event": "#/$defs/CompactionRuntimeEvent",
       "done": "#/$defs/DoneRuntimeEvent",
       "error": "#/$defs/ErrorRuntimeEvent",
       "new_response": "#/$defs/NewResponseRuntimeEvent",
@@ -742,6 +811,9 @@
     },
     {
       "$ref": "#/$defs/NewResponseRuntimeEvent"
+    },
+    {
+      "$ref": "#/$defs/CompactionRuntimeEvent"
     },
     {
       "$ref": "#/$defs/DoneRuntimeEvent"

--- a/backend/tests/test_runtime_events.py
+++ b/backend/tests/test_runtime_events.py
@@ -77,6 +77,13 @@ def test_runtime_event_snapshot_lists_every_expected_event_type() -> None:
             "verification": {"verdict": "pass"},
         },
         {"type": "new_response"},
+        {
+            "type": "compaction_event",
+            "from_turn": 1,
+            "to_turn": 4,
+            "summary": "Compacted early turns.",
+            "saved_tokens": 1200,
+        },
         {"type": "done", "content": "final"},
         {"type": "error", "error": "boom"},
     ],

--- a/frontend/src/lib/chat-stream-events.ts
+++ b/frontend/src/lib/chat-stream-events.ts
@@ -111,6 +111,15 @@ export function parseChatStreamEventPayload(payload: unknown): ChatStreamEvent {
       };
     case "new_response":
       return { type: "new_response", ...base };
+    case "compaction_event":
+      return {
+        type: "compaction_event",
+        from_turn: event.from_turn,
+        to_turn: event.to_turn,
+        summary: event.summary,
+        saved_tokens: event.saved_tokens,
+        ...base,
+      };
     case "done":
       return {
         type: "done",

--- a/frontend/src/lib/chat-stream-reducer.ts
+++ b/frontend/src/lib/chat-stream-reducer.ts
@@ -143,6 +143,12 @@ export function applyStreamEvent(
       }));
     case "new_response":
       return reduceNewResponseEvent(state, event, options);
+    case "compaction_event":
+      return {
+        messages: state.messages,
+        streamingMessageId: state.streamingMessageId,
+        finished: false,
+      };
     case "done":
       return reduceDoneEvent(state, event, options.now);
     case "error":

--- a/frontend/src/lib/runtime-events.test.ts
+++ b/frontend/src/lib/runtime-events.test.ts
@@ -78,6 +78,14 @@ function minimalPayloadFor(eventType: string): Record<string, unknown> {
       };
     case "new_response":
       return { type: "new_response" };
+    case "compaction_event":
+      return {
+        type: "compaction_event",
+        from_turn: 1,
+        to_turn: 4,
+        summary: "Compacted early turns.",
+        saved_tokens: 1200,
+      };
     case "done":
       return { type: "done", content: "final answer" };
     case "error":

--- a/frontend/src/lib/runtime-events.ts
+++ b/frontend/src/lib/runtime-events.ts
@@ -23,6 +23,7 @@ export const RUNTIME_EVENT_TYPES = [
   "plan_updated",
   "verification_result",
   "new_response",
+  "compaction_event",
   "done",
   "error",
 ] as const;
@@ -147,6 +148,19 @@ const NewResponseRuntimeEventSchema = z
   })
   .strict();
 
+const CompactionRuntimeEventSchema = z
+  .object({
+    type: z.literal("compaction_event"),
+    schema_version: schemaVersionField,
+    request_id: requestIdField,
+    event_index: eventIndexField,
+    from_turn: z.number().int(),
+    to_turn: z.number().int(),
+    summary: z.string(),
+    saved_tokens: z.number().int(),
+  })
+  .strict();
+
 const DoneRuntimeEventSchema = z
   .object({
     type: z.literal("done"),
@@ -177,6 +191,7 @@ export const RuntimeEventSchema = z.discriminatedUnion("type", [
   PlanUpdatedRuntimeEventSchema,
   VerificationResultRuntimeEventSchema,
   NewResponseRuntimeEventSchema,
+  CompactionRuntimeEventSchema,
   DoneRuntimeEventSchema,
   ErrorRuntimeEventSchema,
 ]);
@@ -195,6 +210,7 @@ export const RUNTIME_EVENT_SCHEMAS: Record<
   plan_updated: PlanUpdatedRuntimeEventSchema,
   verification_result: VerificationResultRuntimeEventSchema,
   new_response: NewResponseRuntimeEventSchema,
+  compaction_event: CompactionRuntimeEventSchema,
   done: DoneRuntimeEventSchema,
   error: ErrorRuntimeEventSchema,
 };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -315,6 +315,14 @@ export interface ChatStreamNewResponseEvent extends ChatStreamEventBase {
   type: "new_response";
 }
 
+export interface ChatStreamCompactionEvent extends ChatStreamEventBase {
+  type: "compaction_event";
+  from_turn: number;
+  to_turn: number;
+  summary: string;
+  saved_tokens: number;
+}
+
 export interface ChatStreamDoneEvent extends ChatStreamEventBase {
   type: "done";
   content: string;
@@ -345,6 +353,7 @@ export type ChatStreamEvent =
   | ChatStreamPlanUpdatedEvent
   | ChatStreamVerificationResultEvent
   | ChatStreamNewResponseEvent
+  | ChatStreamCompactionEvent
   | ChatStreamDoneEvent
   | ChatStreamErrorEvent
   | ChatStreamParseErrorEvent;


### PR DESCRIPTION
## Summary
This PR introduces a new `CompactionRuntimeEvent` type to support conversation history compression. This event allows the system to indicate when multiple conversation turns have been compacted into a summary, along with the token savings achieved.

## Key Changes

- **Backend (Python)**
  - Added `CompactionRuntimeEvent` class in `events.py` with fields for turn range (`from_turn`, `to_turn`), summary text, and token savings
  - Updated the `RuntimeEvent` union type to include the new event class
  - Added event type to the `RUNTIME_EVENT_TYPES` tuple

- **Frontend (TypeScript)**
  - Added `CompactionRuntimeEventSchema` to the Zod schema validation in `runtime-events.ts`
  - Created `ChatStreamCompactionEvent` interface in `types.ts` with the same fields as the backend
  - Updated `ChatStreamEvent` union type to include the new event type
  - Added parsing logic in `chat-stream-events.ts` to handle compaction events
  - Updated `chat-stream-reducer.ts` to pass through compaction events without modifying message state

- **Schema**
  - Updated `events.schema.json` with the complete JSON schema definition for `CompactionRuntimeEvent`
  - Added discriminator mapping for the new event type

- **Tests**
  - Added test fixtures in `runtime-events.test.ts` and `test_runtime_events.py` to validate the new event type

## Implementation Details

The `CompactionRuntimeEvent` includes:
- `from_turn` and `to_turn`: Integer indices defining the range of turns being compacted
- `summary`: String containing the compressed representation of the conversation
- `saved_tokens`: Integer indicating the number of tokens saved by the compaction
- Standard event fields: `type`, `schema_version`, `request_id`, `event_index`

The event is treated as informational in the reducer—it updates neither the message list nor the streaming state, allowing the UI to display compaction information without disrupting the conversation flow.

https://claude.ai/code/session_016mAFjyvEzBB4PQgAU72hcc