### PR TITLE
Implement path-gating for skills with explicit path declarations

### DIFF
--- a/backend/graph/skill_router.py
+++ b/backend/graph/skill_router.py
@@ -345,33 +345,33 @@ def _path_hint_matches(path_hint: str, candidate_path: str) -> bool:
     )
 
 
-def _entry_declares_paths(entry: dict[str, Any]) -> bool:
-    path_hints = entry.get("paths", [])
-    if not isinstance(path_hints, list):
-        return False
-    return any(isinstance(p, str) and p.strip() for p in path_hints)
-
-
 def _score_path_activation(
     entry: dict[str, Any],
     *,
     query_paths: list[str],
     history_paths: list[str],
-) -> int:
+) -> tuple[int, bool]:
+    """Return (activation_score, declared).
+
+    `declared` is True iff the skill carries a non-empty `paths:` list;
+    when score == 0 this signals the skill is path-gated rather than
+    always-on.
+    """
     path_hints = entry.get("paths", [])
-    if not isinstance(path_hints, list) or not path_hints:
-        return 0
+    if not isinstance(path_hints, list):
+        return 0, False
+    valid_hints = [p for p in path_hints if isinstance(p, str) and p.strip()]
+    if not valid_hints:
+        return 0, False
 
     score = 0
-    for path_hint in path_hints:
-        if not isinstance(path_hint, str):
-            continue
+    for path_hint in valid_hints:
         specificity = _path_hint_specificity(path_hint)
         if any(_path_hint_matches(path_hint, candidate) for candidate in query_paths):
             score = max(score, _PATH_ACTIVATION_SCORE + specificity)
         if any(_path_hint_matches(path_hint, candidate) for candidate in history_paths):
             score = max(score, _HISTORY_PATH_ACTIVATION_SCORE + specificity)
-    return score
+    return score, True
 
 
 def select_skill_entries_for_query(
@@ -402,7 +402,7 @@ def select_skill_entries_for_query(
             normalized_query=normalized_query,
             query_tokens=query_tokens,
         )
-        path_score = _score_path_activation(
+        path_score, path_declared = _score_path_activation(
             entry,
             query_paths=query_paths,
             history_paths=history_paths,
@@ -412,7 +412,7 @@ def select_skill_entries_for_query(
         # working set. Empty/absent paths remain always-on. Explicit
         # name/alias invocations bypass this gate so users can still
         # summon a path-scoped skill off-path.
-        if not explicit and path_score == 0 and _entry_declares_paths(entry):
+        if not explicit and path_declared and path_score == 0:
             continue
         score = text_score + path_score
         if score > 0:

--- a/backend/graph/skill_router.py
+++ b/backend/graph/skill_router.py
@@ -345,6 +345,13 @@ def _path_hint_matches(path_hint: str, candidate_path: str) -> bool:
     )
 
 
+def _entry_declares_paths(entry: dict[str, Any]) -> bool:
+    path_hints = entry.get("paths", [])
+    if not isinstance(path_hints, list):
+        return False
+    return any(isinstance(p, str) and p.strip() for p in path_hints)
+
+
 def _score_path_activation(
     entry: dict[str, Any],
     *,
@@ -400,6 +407,13 @@ def select_skill_entries_for_query(
             query_paths=query_paths,
             history_paths=history_paths,
         )
+        # Skills declaring `paths:` are conditionally activated — only
+        # injected when at least one declared hint matches the current
+        # working set. Empty/absent paths remain always-on. Explicit
+        # name/alias invocations bypass this gate so users can still
+        # summon a path-scoped skill off-path.
+        if not explicit and path_score == 0 and _entry_declares_paths(entry):
+            continue
         score = text_score + path_score
         if score > 0:
             scored_entries.append((score, explicit, entry))

--- a/backend/tests/test_prompt_builder.py
+++ b/backend/tests/test_prompt_builder.py
@@ -573,6 +573,75 @@ class TestSkillRouting:
         assert selected is not None
         assert selected[0]["name"] == "memory_curator"
 
+    def test_skill_router_gates_out_path_scoped_skill_when_no_path_matches(self, workspace):
+        _write_skill(
+            workspace,
+            "runtime_debugger",
+            "Inspect backend runtime paths.",
+            category="bio/compute",
+            tags="runtime, debugger",
+            paths="backend/runtime/**",
+            modality="compute",
+            stage="utilities",
+        )
+        _write_skill(
+            workspace,
+            "paper_triage",
+            "Classify relevance of a paper abstract.",
+            category="bio/literature",
+            tags="paper, abstract, literature",
+            modality="literature",
+            stage="interpretation",
+        )
+
+        selected = select_skill_entries_for_query(
+            workspace,
+            "triage this paper abstract about runtime scheduling",
+        )
+
+        assert selected is not None
+        names = {entry["name"] for entry in selected}
+        assert "runtime_debugger" not in names
+        assert "paper_triage" in names
+
+    def test_skill_router_keeps_skill_without_paths_as_always_on(self, workspace):
+        _write_skill(
+            workspace,
+            "paper_triage",
+            "Classify relevance of a paper abstract.",
+            category="bio/literature",
+            tags="paper, abstract, literature",
+            modality="literature",
+            stage="interpretation",
+        )
+
+        selected = select_skill_entries_for_query(
+            workspace,
+            "triage this paper abstract",
+        )
+
+        assert selected is not None
+        assert [entry["name"] for entry in selected] == ["paper_triage"]
+
+    def test_skill_router_allows_explicit_invocation_to_bypass_path_gate(self, workspace):
+        _write_skill(
+            workspace,
+            "runtime_debugger",
+            "Inspect backend runtime paths.",
+            category="bio/compute",
+            paths="backend/runtime/**",
+            modality="compute",
+            stage="utilities",
+        )
+
+        selected = select_skill_entries_for_query(
+            workspace,
+            "use runtime_debugger to brainstorm checks",
+        )
+
+        assert selected is not None
+        assert [entry["name"] for entry in selected] == ["runtime_debugger"]
+
 
 class TestRetrievedMemoryBlock:
     def test_retrieved_memory_block_includes_typed_metadata_compactly(self):


### PR DESCRIPTION
## Summary
This change introduces path-gating logic for skills that declare path hints. Skills with explicit `paths:` declarations are now conditionally activated only when at least one path hint matches the current working context, while skills without path declarations remain always-on. Users can still explicitly invoke path-gated skills by name, bypassing the gate.

## Key Changes
- **Modified `_score_path_activation()` return type**: Now returns a tuple `(activation_score, declared)` where `declared` indicates whether the skill carries a non-empty `paths:` list. This distinction allows the router to differentiate between path-gated skills (score=0 but declared=True) and always-on skills (score=0 and declared=False).

- **Added path-gating logic in `select_skill_entries_for_query()`**: Skills with declared paths are filtered out when:
  - No explicit name/alias invocation is used (`not explicit`)
  - The skill declares path hints (`path_declared`)
  - No path hints match the current context (`path_score == 0`)

- **Improved path hint validation**: The `_score_path_activation()` function now properly validates path hints, filtering out non-string and whitespace-only entries before processing.

## Implementation Details
- The gating mechanism preserves backward compatibility: skills without `paths:` declarations continue to be always-on
- Explicit skill invocations (e.g., "use runtime_debugger to...") bypass the path gate, allowing users to summon path-scoped skills regardless of context
- Path specificity scoring remains unchanged; the new logic only affects whether a skill is considered at all

https://claude.ai/code/session_01HWfKwkDpFhebUZ34opYHFM