### PR TITLE
feat: ToolResult needs_approval + streaming_chunk variants end-to-end (#24)

### DIFF
--- a/backend/graph/agent.py
+++ b/backend/graph/agent.py
@@ -201,17 +201,51 @@ class AgentManager:
                     run_id = event["run_id"]
                     raw_output = event["data"].get("output", "")
                     result = normalize_tool_output(event["name"], raw_output)
+                    raw_input = event["data"].get("input", {})
+                    if isinstance(raw_input, dict) and len(raw_input) == 1:
+                        tool_input_str = str(next(iter(raw_input.values())))
+                    else:
+                        tool_input_str = str(raw_input)
+
+                    result_dict = result.model_dump(mode="json")
+                    policy = result.metadata.get("policy")
+                    policy_dict = policy if isinstance(policy, dict) else None
+
+                    if result.outcome == "needs_approval":
+                        approval_message = (
+                            result.error.message
+                            if result.error is not None
+                            else result.summary
+                        )
+                        approval_reason = (
+                            policy_dict.get("approval_reason")
+                            if isinstance(policy_dict, dict)
+                            else None
+                        ) or "requires_approval"
+                        payload = {
+                            "type": "tool_awaiting_approval",
+                            "tool": event["name"],
+                            "input": tool_input_str,
+                            "run_id": run_id,
+                            "reason": approval_reason,
+                            "message": approval_message,
+                            "result": result_dict,
+                        }
+                        if policy_dict is not None:
+                            payload["policy"] = policy_dict
+                        yield payload
+                        after_tool = True
+                        continue
 
                     payload = {
                         "type": "tool_end",
                         "tool": event["name"],
                         "output": result.summary,
-                        "result": result.model_dump(mode="json"),
+                        "result": result_dict,
                         "run_id": run_id,
                     }
-                    policy = result.metadata.get("policy")
-                    if isinstance(policy, dict):
-                        payload["policy"] = policy
+                    if policy_dict is not None:
+                        payload["policy"] = policy_dict
                     yield payload
                     after_tool = True
 

--- a/backend/runtime/events.py
+++ b/backend/runtime/events.py
@@ -65,6 +65,40 @@ class ToolEndRuntimeEvent(_RuntimeEventBase):
     policy: Optional[dict[str, Any]] = None
 
 
+class ToolAwaitingApprovalRuntimeEvent(_RuntimeEventBase):
+    """Emitted when policy gates a tool call pending human approval.
+
+    Replaces (does not accompany) the `tool_end` event for that run_id; the
+    underlying tool was not invoked. The frontend renders an inline gate so a
+    reviewer can approve or deny the call before the turn resumes.
+    """
+
+    type: Literal["tool_awaiting_approval"] = "tool_awaiting_approval"
+    tool: str
+    input: str
+    run_id: str
+    reason: str
+    message: str
+    result: Optional[dict[str, Any]] = None
+    policy: Optional[dict[str, Any]] = None
+
+
+class ToolChunkRuntimeEvent(_RuntimeEventBase):
+    """Mid-tool partial output for streaming-capable tools.
+
+    Always followed by a terminal `tool_end` for the same `run_id`. Chunks are
+    transport-only — they are not persisted in session JSON; only the final
+    `tool_end` envelope is.
+    """
+
+    type: Literal["tool_chunk"] = "tool_chunk"
+    tool: str
+    run_id: str
+    chunk_index: int = Field(ge=0)
+    chunk: str
+    terminal: bool = False
+
+
 class PlanCreatedRuntimeEvent(_RuntimeEventBase):
     type: Literal["plan_created"] = "plan_created"
     summary: str
@@ -119,6 +153,8 @@ RuntimeEvent = Annotated[
         TokenRuntimeEvent,
         ToolStartRuntimeEvent,
         ToolEndRuntimeEvent,
+        ToolAwaitingApprovalRuntimeEvent,
+        ToolChunkRuntimeEvent,
         PlanCreatedRuntimeEvent,
         PlanUpdatedRuntimeEvent,
         VerificationResultRuntimeEvent,
@@ -135,6 +171,8 @@ RUNTIME_EVENT_TYPES: tuple[str, ...] = (
     "token",
     "tool_start",
     "tool_end",
+    "tool_awaiting_approval",
+    "tool_chunk",
     "plan_created",
     "plan_updated",
     "verification_result",

--- a/backend/runtime/events.schema.json
+++ b/backend/runtime/events.schema.json
@@ -521,6 +521,181 @@
       "title": "TokenRuntimeEvent",
       "type": "object"
     },
+    "ToolAwaitingApprovalRuntimeEvent": {
+      "additionalProperties": false,
+      "description": "Emitted when policy gates a tool call pending human approval.\n\nReplaces (does not accompany) the `tool_end` event for that run_id; the\nunderlying tool was not invoked. The frontend renders an inline gate so a\nreviewer can approve or deny the call before the turn resumes.",
+      "properties": {
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "input": {
+          "title": "Input",
+          "type": "string"
+        },
+        "message": {
+          "title": "Message",
+          "type": "string"
+        },
+        "policy": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Policy"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Result"
+        },
+        "run_id": {
+          "title": "Run Id",
+          "type": "string"
+        },
+        "schema_version": {
+          "default": 1,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "tool": {
+          "title": "Tool",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_awaiting_approval",
+          "default": "tool_awaiting_approval",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool",
+        "input",
+        "run_id",
+        "reason",
+        "message"
+      ],
+      "title": "ToolAwaitingApprovalRuntimeEvent",
+      "type": "object"
+    },
+    "ToolChunkRuntimeEvent": {
+      "additionalProperties": false,
+      "description": "Mid-tool partial output for streaming-capable tools.\n\nAlways followed by a terminal `tool_end` for the same `run_id`. Chunks are\ntransport-only \u2014 they are not persisted in session JSON; only the final\n`tool_end` envelope is.",
+      "properties": {
+        "chunk": {
+          "title": "Chunk",
+          "type": "string"
+        },
+        "chunk_index": {
+          "minimum": 0,
+          "title": "Chunk Index",
+          "type": "integer"
+        },
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "run_id": {
+          "title": "Run Id",
+          "type": "string"
+        },
+        "schema_version": {
+          "default": 1,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "terminal": {
+          "default": false,
+          "title": "Terminal",
+          "type": "boolean"
+        },
+        "tool": {
+          "title": "Tool",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_chunk",
+          "default": "tool_chunk",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool",
+        "run_id",
+        "chunk_index",
+        "chunk"
+      ],
+      "title": "ToolChunkRuntimeEvent",
+      "type": "object"
+    },
     "ToolEndRuntimeEvent": {
       "additionalProperties": false,
       "properties": {
@@ -781,6 +956,8 @@
       "plan_updated": "#/$defs/PlanUpdatedRuntimeEvent",
       "retrieval": "#/$defs/RetrievalRuntimeEvent",
       "token": "#/$defs/TokenRuntimeEvent",
+      "tool_awaiting_approval": "#/$defs/ToolAwaitingApprovalRuntimeEvent",
+      "tool_chunk": "#/$defs/ToolChunkRuntimeEvent",
       "tool_end": "#/$defs/ToolEndRuntimeEvent",
       "tool_start": "#/$defs/ToolStartRuntimeEvent",
       "verification_result": "#/$defs/VerificationResultRuntimeEvent"
@@ -799,6 +976,12 @@
     },
     {
       "$ref": "#/$defs/ToolEndRuntimeEvent"
+    },
+    {
+      "$ref": "#/$defs/ToolAwaitingApprovalRuntimeEvent"
+    },
+    {
+      "$ref": "#/$defs/ToolChunkRuntimeEvent"
     },
     {
       "$ref": "#/$defs/PlanCreatedRuntimeEvent"

--- a/backend/runtime/query_engine.py
+++ b/backend/runtime/query_engine.py
@@ -391,6 +391,14 @@ class QueryEngine:
             payload = dict(event)
             payload["run_id"] = event.get("run_id", event["tool"])
             return cls._attach_policy_payload(payload, event.get("result"))
+        if event_type == "tool_awaiting_approval":
+            payload = dict(event)
+            payload["run_id"] = event.get("run_id", event["tool"])
+            return cls._attach_policy_payload(payload, event.get("result"))
+        if event_type == "tool_chunk":
+            payload = dict(event)
+            payload["run_id"] = event.get("run_id", event["tool"])
+            return payload
         if event_type == "new_response":
             return {"type": "new_response"}
         return event

--- a/backend/tests/test_runtime_events.py
+++ b/backend/tests/test_runtime_events.py
@@ -61,6 +61,22 @@ def test_runtime_event_snapshot_lists_every_expected_event_type() -> None:
             "result": {"status": "success"},
         },
         {
+            "type": "tool_awaiting_approval",
+            "tool": "terminal",
+            "input": "rm -rf /",
+            "run_id": "run-2",
+            "reason": "requires_approval",
+            "message": "Approve before running.",
+        },
+        {
+            "type": "tool_chunk",
+            "tool": "terminal",
+            "run_id": "run-2",
+            "chunk_index": 0,
+            "chunk": "partial output...",
+            "terminal": False,
+        },
+        {
             "type": "plan_created",
             "summary": "planner",
             "plan": {"goal": "g", "steps": []},
@@ -125,6 +141,19 @@ def test_build_runtime_event_rejects_unknown_event_type() -> None:
 def test_build_runtime_event_rejects_extra_fields() -> None:
     with pytest.raises(ValidationError):
         build_runtime_event({"type": "token", "content": "hi", "surprise": True})
+
+
+def test_build_runtime_event_rejects_negative_chunk_index() -> None:
+    with pytest.raises(ValidationError):
+        build_runtime_event(
+            {
+                "type": "tool_chunk",
+                "tool": "terminal",
+                "run_id": "run-1",
+                "chunk_index": -1,
+                "chunk": "x",
+            }
+        )
 
 
 def test_build_runtime_event_rejects_bad_verdict() -> None:

--- a/backend/tests/test_tool_output_contracts.py
+++ b/backend/tests/test_tool_output_contracts.py
@@ -12,9 +12,55 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from tools.contracts import (
     MAX_SOURCE_PAYLOAD_JSON_CHARS,
     MAX_STRUCTURED_PAYLOAD_JSON_CHARS,
+    needs_approval_result,
     normalize_tool_output,
+    streaming_chunk_result,
     success_result,
 )
+
+
+def test_needs_approval_result_marks_envelope_with_typed_error():
+    summary, artifact = needs_approval_result(
+        "terminal",
+        "Tool gated by policy.",
+        metadata={"policy_approval_reason": "requires_approval"},
+    )
+
+    assert summary.startswith("[NEEDS_APPROVAL]")
+    assert artifact["status"] == "error"
+    assert artifact["outcome"] == "needs_approval"
+    assert artifact["error"]["code"] == "needs_approval"
+    assert artifact["error"]["retriable"] is False
+    assert artifact["metadata"]["policy_approval_reason"] == "requires_approval"
+
+
+def test_streaming_chunk_result_is_classified_as_success_with_chunk_metadata():
+    summary, artifact = streaming_chunk_result(
+        "terminal",
+        "stdout chunk",
+        chunk_index=2,
+        chunk="hello world\n",
+    )
+
+    assert summary == "stdout chunk"
+    assert artifact["status"] == "success"
+    assert artifact["outcome"] == "streaming_chunk"
+    assert artifact["error"] is None
+    assert artifact["metadata"]["chunk_index"] == 2
+    assert artifact["metadata"]["chunk_terminal"] is False
+    assert artifact["metadata"]["chunk_text"] == "hello world\n"
+
+
+def test_streaming_chunk_result_rejects_negative_chunk_index():
+    import pytest
+
+    with pytest.raises(ValueError):
+        streaming_chunk_result(
+            "terminal",
+            "x",
+            chunk_index=-1,
+            chunk="x",
+        )
 
 
 def test_normalize_tool_output_classifies_legacy_blocked_messages():

--- a/backend/tests/test_tool_policy.py
+++ b/backend/tests/test_tool_policy.py
@@ -17,6 +17,7 @@ def test_policy_wrapper_allows_execution_tool_and_keeps_policy_metadata(tmp_path
             session_id="session-1",
             request_id="request-1",
             allowed_access_scope="execution",
+            approved_tool_runs=frozenset({"terminal"}),
         )
     ):
         summary, artifact = terminal._run(command="pwd")
@@ -26,6 +27,50 @@ def test_policy_wrapper_allows_execution_tool_and_keeps_policy_metadata(tmp_path
     assert artifact["metadata"]["policy"]["block_reason"] is None
     assert artifact["metadata"]["policy"]["status"] == "allow"
     assert artifact["warnings"] == []
+
+
+def test_policy_wrapper_short_circuits_to_needs_approval_for_gated_tool(tmp_path):
+    runtime_tools = get_runtime_tools(tmp_path)
+    terminal = next(tool for tool in runtime_tools if tool.name == "terminal")
+
+    with tool_policy_context(
+        ToolPolicyExecutionContext(
+            session_id="session-1",
+            request_id="request-1",
+            allowed_access_scope="execution",
+        )
+    ):
+        summary, artifact = terminal._run(command="pwd")
+
+    assert summary.startswith("[NEEDS_APPROVAL]")
+    assert artifact["outcome"] == "needs_approval"
+    assert artifact["status"] == "error"
+    assert artifact["error"]["code"] == "needs_approval"
+    assert artifact["metadata"]["policy"]["status"] == "needs_approval"
+    assert artifact["metadata"]["policy"]["approval_reason"] == "requires_approval"
+    assert artifact["metadata"]["contract"]["requires_approval"] is True
+
+
+def test_policy_wrapper_skips_approval_when_run_already_approved(tmp_path):
+    runtime_tools = get_runtime_tools(tmp_path)
+    write_file = next(tool for tool in runtime_tools if tool.name == "write_file")
+
+    with tool_policy_context(
+        ToolPolicyExecutionContext(
+            session_id="session-1",
+            request_id="request-1",
+            allowed_access_scope="execution",
+            approved_tool_runs=frozenset({"write_file"}),
+        )
+    ):
+        summary, artifact = write_file._run(
+            path="memory/notes.txt",
+            content="approved write",
+        )
+
+    assert artifact["outcome"] == "success"
+    assert "Wrote memory/notes.txt" in summary
+    assert artifact["metadata"]["policy"]["status"] == "allow"
 
 
 def test_policy_wrapper_annotates_successful_tool_results(tmp_path):

--- a/backend/tools/contracts.py
+++ b/backend/tools/contracts.py
@@ -25,13 +25,23 @@ ToolResultOutcome = Literal[
     "invalid_input",
     "retriable_failure",
     "execution_failure",
+    "needs_approval",
+    "streaming_chunk",
 ]
 ToolErrorCode = Literal[
     "blocked",
     "invalid_input",
     "retriable_failure",
     "execution_failure",
+    "needs_approval",
 ]
+
+# Outcomes whose semantics are "the tool didn't fail" — used when deriving
+# the binary `status` field. `streaming_chunk` is a non-terminal partial
+# result, so it stays on the success side of the wall.
+_SUCCESSFUL_OUTCOMES: frozenset[str] = frozenset(
+    {"success", "success_empty", "streaming_chunk"}
+)
 
 _TRUNCATED_MARKERS = ("[output truncated]", "...[truncated]")
 _INVALID_INPUT_PATTERNS = (
@@ -253,6 +263,68 @@ def execution_error_result(
     )
 
 
+def needs_approval_result(
+    tool_name: str,
+    message: str,
+    *,
+    structured_payload: JsonLike = None,
+    artifact_refs: list[ToolArtifactRef] | None = None,
+    warnings: list[str] | None = None,
+    metadata: dict[str, JsonLike] | None = None,
+    source_payload: JsonLike = None,
+) -> tuple[str, dict[str, Any]]:
+    summary = message if message.startswith("[NEEDS_APPROVAL]") else f"[NEEDS_APPROVAL] {message}"
+    error_message = (
+        summary.removeprefix("[NEEDS_APPROVAL]").strip()
+        or "Tool requires human approval before it can run."
+    )
+    return build_tool_result(
+        tool_name,
+        summary,
+        structured_payload=structured_payload,
+        artifact_refs=artifact_refs,
+        warnings=warnings,
+        metadata=metadata,
+        source_payload=source_payload,
+        outcome="needs_approval",
+        error=ToolResultError(code="needs_approval", message=error_message, retriable=False),
+    )
+
+
+def streaming_chunk_result(
+    tool_name: str,
+    summary: str,
+    *,
+    chunk_index: int,
+    chunk: str,
+    terminal: bool = False,
+    structured_payload: JsonLike = None,
+    artifact_refs: list[ToolArtifactRef] | None = None,
+    warnings: list[str] | None = None,
+    metadata: dict[str, JsonLike] | None = None,
+    source_payload: JsonLike = None,
+) -> tuple[str, dict[str, Any]]:
+    if chunk_index < 0:
+        raise ValueError("chunk_index must be a non-negative integer")
+    chunk_metadata: dict[str, JsonLike] = {
+        "chunk_index": chunk_index,
+        "chunk_terminal": terminal,
+        "chunk_text": chunk,
+    }
+    merged_metadata: dict[str, JsonLike] = dict(metadata or {})
+    merged_metadata.update(chunk_metadata)
+    return build_tool_result(
+        tool_name,
+        summary,
+        structured_payload=structured_payload,
+        artifact_refs=artifact_refs,
+        warnings=warnings,
+        metadata=merged_metadata,
+        source_payload=source_payload,
+        outcome="streaming_chunk",
+    )
+
+
 def build_tool_result(
     tool_name: str,
     summary: str,
@@ -289,7 +361,9 @@ def build_tool_result(
     if source_truncated and "source_payload_truncated" not in normalized_warnings:
         normalized_warnings.append("source_payload_truncated")
 
-    status: ToolResultStatus = "error" if outcome not in ("success", "success_empty") or error else "success"
+    status: ToolResultStatus = (
+        "error" if outcome not in _SUCCESSFUL_OUTCOMES or error else "success"
+    )
     envelope = ToolResultEnvelope(
         tool_name=tool_name,
         summary=normalized_summary,
@@ -563,8 +637,10 @@ __all__ = [
     "invalid_input_result",
     "is_tool_result_dict",
     "json_to_pretty_text",
+    "needs_approval_result",
     "normalize_tool_output",
     "retriable_error_result",
+    "streaming_chunk_result",
     "success_result",
     "truncate_text",
 ]

--- a/backend/tools/policy.py
+++ b/backend/tools/policy.py
@@ -68,10 +68,31 @@ def evaluate_pre_tool_policy(
             block_message="Execution-scoped tool execution is not allowed in this runtime context.",
         )
 
+    if manifest.requires_approval and not _user_has_approved(manifest, context):
+        return ToolPolicyDecision(
+            status="needs_approval",
+            approval_reason="requires_approval",
+            approval_message=(
+                f"Tool '{manifest.name}' is gated and needs human approval before it can run."
+            ),
+        )
+
     if warnings:
         return ToolPolicyDecision(status="allow_with_warning", warnings=tuple(warnings))
 
     return ToolPolicyDecision(status="allow")
+
+
+def _user_has_approved(
+    manifest: ToolManifestEntry,
+    context: ToolPolicyExecutionContext,
+) -> bool:
+    approved = context.approved_tool_runs
+    if not approved:
+        return False
+    if manifest.name in approved:
+        return True
+    return False
 
 
 def annotate_tool_result(
@@ -102,6 +123,7 @@ def annotate_tool_result(
         status=decision.status,
         warnings=tuple(decision.warnings),
         block_reason=decision.block_reason,
+        approval_reason=decision.approval_reason,
     )
 
     metadata = dict(result.metadata)
@@ -112,6 +134,7 @@ def annotate_tool_result(
         "status": annotation.status,
         "warnings": list(annotation.warnings),
         "block_reason": annotation.block_reason,
+        "approval_reason": annotation.approval_reason,
     }
     metadata["contract"] = {
         "output_contract_version": manifest.output_contract_version,
@@ -124,6 +147,7 @@ def annotate_tool_result(
         "result_summary_hint": manifest.result_summary_hint,
         "planner_exposed": manifest.planner_exposed,
         "verifier_exposed": manifest.verifier_exposed,
+        "requires_approval": manifest.requires_approval,
     }
 
     result.warnings = warnings

--- a/backend/tools/policy_types.py
+++ b/backend/tools/policy_types.py
@@ -5,7 +5,12 @@ from typing import Literal
 
 from .registry import EvidenceRequirement, ToolAccessScope
 
-ToolPolicyStatus = Literal["allow", "allow_with_warning", "blocked"]
+ToolPolicyStatus = Literal[
+    "allow",
+    "allow_with_warning",
+    "blocked",
+    "needs_approval",
+]
 
 
 @dataclass
@@ -14,6 +19,10 @@ class ToolPolicyExecutionContext:
     request_id: str | None = None
     turn_id: str | None = None
     allowed_access_scope: ToolAccessScope = "execution"
+    # Set of `tool_name` (or `f"{tool_name}:{run_id}"`) strings the user has
+    # already approved this turn. The runtime is responsible for populating
+    # this from the approval API; the policy layer only consults it.
+    approved_tool_runs: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -22,6 +31,8 @@ class ToolPolicyDecision:
     warnings: tuple[str, ...] = ()
     block_reason: str | None = None
     block_message: str | None = None
+    approval_reason: str | None = None
+    approval_message: str | None = None
 
 
 @dataclass(frozen=True)
@@ -32,3 +43,4 @@ class ToolPolicyAnnotation:
     status: ToolPolicyStatus
     warnings: tuple[str, ...] = ()
     block_reason: str | None = None
+    approval_reason: str | None = None

--- a/backend/tools/policy_wrappers.py
+++ b/backend/tools/policy_wrappers.py
@@ -15,6 +15,7 @@ from .contracts import (
     ToolResultEnvelope,
     blocked_result,
     execution_error_result,
+    needs_approval_result,
     normalize_tool_output,
     retriable_error_result,
 )
@@ -239,6 +240,16 @@ class PolicyWrappedTool(BaseTool):
                 decision.block_message or "Blocked by BioAPEX runtime policy.",
                 metadata={"policy_block_reason": decision.block_reason},
             )
+        elif decision.status == "needs_approval":
+            raw_output = needs_approval_result(
+                self.name,
+                decision.approval_message
+                or f"Tool '{self.name}' requires human approval before it can run.",
+                metadata={
+                    "policy_approval_reason": decision.approval_reason,
+                    "requires_approval": True,
+                },
+            )
         else:
             try:
                 raw_output = self.wrapped_tool._run(*args, **kwargs)
@@ -272,6 +283,16 @@ class PolicyWrappedTool(BaseTool):
                 self.name,
                 decision.block_message or "Blocked by BioAPEX runtime policy.",
                 metadata={"policy_block_reason": decision.block_reason},
+            )
+        elif decision.status == "needs_approval":
+            raw_output = needs_approval_result(
+                self.name,
+                decision.approval_message
+                or f"Tool '{self.name}' requires human approval before it can run.",
+                metadata={
+                    "policy_approval_reason": decision.approval_reason,
+                    "requires_approval": True,
+                },
             )
         else:
             try:

--- a/backend/tools/registry.py
+++ b/backend/tools/registry.py
@@ -27,6 +27,7 @@ class ToolPolicyMetadata:
     tool_validates_input: bool = False
     activity_summary_hint: str | None = None
     result_summary_hint: str | None = None
+    requires_approval: bool = False
 
 
 @dataclass(frozen=True)
@@ -48,6 +49,7 @@ class ToolManifestEntry:
     tool_validates_input: bool = False
     activity_summary_hint: str | None = None
     result_summary_hint: str | None = None
+    requires_approval: bool = False
 
 
 @dataclass(frozen=True)
@@ -59,11 +61,13 @@ class ToolRegistry:
 _POLICY_OVERRIDES: dict[str, ToolPolicyMetadata] = {
     "terminal": ToolPolicyMetadata(
         access_scope="execution",
+        requires_approval=True,
         activity_summary_hint="State the command goal and the target environment before running it.",
         result_summary_hint="Summarize the command outcome, key stdout or stderr signals, and any file or process side effects.",
     ),
     "python_repl": ToolPolicyMetadata(
         access_scope="execution",
+        requires_approval=True,
         activity_summary_hint="State the code goal and the data or files it will touch before executing it.",
         result_summary_hint="Summarize the computed result, warnings, and any files or variables materially changed.",
     ),
@@ -98,6 +102,7 @@ _POLICY_OVERRIDES: dict[str, ToolPolicyMetadata] = {
     "write_file": ToolPolicyMetadata(
         access_scope="execution",
         destructive=True,
+        requires_approval=True,
         interrupt_behavior="avoid_interrupting",
         activity_summary_hint="State what file will be written and why before applying the change.",
         result_summary_hint="Summarize what changed on disk and name the affected file paths.",
@@ -216,6 +221,7 @@ def build_tool_manifest_entry(tool: Any) -> ToolManifestEntry:
         tool_validates_input=tool_validates_input,
         activity_summary_hint=activity_summary_hint,
         result_summary_hint=result_summary_hint,
+        requires_approval=policy.requires_approval,
     )
 
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -586,6 +586,27 @@ function validateSessionContentBlocks(
           );
         }
         break;
+      case "approval_gate":
+        expectStringField(record, "tool", path, blockLabel);
+        expectStringField(record, "input", path, blockLabel);
+        expectStringField(record, "run_id", path, blockLabel);
+        expectStringField(record, "reason", path, blockLabel);
+        expectStringField(record, "message", path, blockLabel);
+        if ("result" in record && record.result != null && !isObjectRecord(record.result)) {
+          throw createPayloadError(
+            path,
+            blockLabel,
+            'Expected "result" to be an object when present.'
+          );
+        }
+        if ("policy" in record && record.policy != null && !isObjectRecord(record.policy)) {
+          throw createPayloadError(
+            path,
+            blockLabel,
+            'Expected "policy" to be an object when present.'
+          );
+        }
+        break;
       default:
         break;
     }

--- a/frontend/src/lib/chat-stream-events.ts
+++ b/frontend/src/lib/chat-stream-events.ts
@@ -81,6 +81,28 @@ export function parseChatStreamEventPayload(payload: unknown): ChatStreamEvent {
         policy: (event.policy ?? undefined) as JsonObject | undefined,
         ...base,
       };
+    case "tool_awaiting_approval":
+      return {
+        type: "tool_awaiting_approval",
+        tool: event.tool,
+        input: event.input,
+        run_id: event.run_id,
+        reason: event.reason,
+        message: event.message,
+        result: (event.result ?? undefined) as ToolResultEnvelope | undefined,
+        policy: (event.policy ?? undefined) as JsonObject | undefined,
+        ...base,
+      };
+    case "tool_chunk":
+      return {
+        type: "tool_chunk",
+        tool: event.tool,
+        run_id: event.run_id,
+        chunk_index: event.chunk_index,
+        chunk: event.chunk,
+        terminal: event.terminal,
+        ...base,
+      };
     case "plan_created":
       return {
         type: "plan_created",

--- a/frontend/src/lib/chat-stream-reducer.test.ts
+++ b/frontend/src/lib/chat-stream-reducer.test.ts
@@ -214,4 +214,112 @@ describe("applyStreamEvent", () => {
       },
     ]);
   });
+
+  it("appends an approval_gate block when the runtime emits tool_awaiting_approval", () => {
+    let state: StreamReducerState = {
+      messages: [createOptimisticAssistantMessage("assistant-1", 100)],
+      streamingMessageId: "assistant-1",
+    };
+
+    state = reduceEvent(
+      state,
+      {
+        type: "tool_start",
+        tool: "terminal",
+        input: "rm -rf /tmp/staging",
+        run_id: "run-approval-1",
+        request_id: "request-approval",
+      },
+      110
+    );
+    state = reduceEvent(
+      state,
+      {
+        type: "tool_awaiting_approval",
+        tool: "terminal",
+        input: "rm -rf /tmp/staging",
+        run_id: "run-approval-1",
+        reason: "requires_approval",
+        message: "Tool 'terminal' is gated and needs human approval before it can run.",
+        request_id: "request-approval",
+      },
+      120
+    );
+
+    const assistant = state.messages[0];
+    expect(assistant.pendingTool).toBeUndefined();
+    const approvalBlock = assistant.blocks?.find(
+      (block) => block.type === "approval_gate"
+    );
+    expect(approvalBlock).toBeDefined();
+    if (approvalBlock?.type === "approval_gate") {
+      expect(approvalBlock.tool).toBe("terminal");
+      expect(approvalBlock.run_id).toBe("run-approval-1");
+      expect(approvalBlock.reason).toBe("requires_approval");
+      expect(approvalBlock.input).toBe("rm -rf /tmp/staging");
+    }
+  });
+
+  it("buffers tool_chunk events and flushes them into the tool_result block on tool_end", () => {
+    let state: StreamReducerState = {
+      messages: [createOptimisticAssistantMessage("assistant-1", 100)],
+      streamingMessageId: "assistant-1",
+    };
+
+    state = reduceEvent(
+      state,
+      {
+        type: "tool_start",
+        tool: "terminal",
+        input: "tail -f log",
+        run_id: "run-stream-1",
+      },
+      110
+    );
+    state = reduceEvent(
+      state,
+      {
+        type: "tool_chunk",
+        tool: "terminal",
+        run_id: "run-stream-1",
+        chunk_index: 0,
+        chunk: "line one\n",
+        terminal: false,
+      },
+      120
+    );
+    state = reduceEvent(
+      state,
+      {
+        type: "tool_chunk",
+        tool: "terminal",
+        run_id: "run-stream-1",
+        chunk_index: 1,
+        chunk: "line two\n",
+        terminal: false,
+      },
+      125
+    );
+    state = reduceEvent(
+      state,
+      {
+        type: "tool_end",
+        tool: "terminal",
+        output: "[final]",
+        run_id: "run-stream-1",
+      },
+      130
+    );
+
+    const assistant = state.messages[0];
+    expect(assistant.toolChunkBuffers).toBeUndefined();
+    const result = assistant.blocks?.find(
+      (block) =>
+        block.type === "tool_result" && block.run_id === "run-stream-1"
+    );
+    expect(result).toBeDefined();
+    if (result?.type === "tool_result") {
+      expect(result.output).toBe("line one\nline two\n[final]");
+    }
+  });
 });

--- a/frontend/src/lib/chat-stream-reducer.ts
+++ b/frontend/src/lib/chat-stream-reducer.ts
@@ -78,6 +78,8 @@ export function applyStreamEvent(
           message.pendingTool?.runId === (event.run_id ?? event.tool)
             ? message.pendingTool
             : null;
+        const runId = event.run_id ?? event.tool;
+        const buffered = takeChunkBuffer(message.toolChunkBuffers, runId);
 
         return {
           ...message,
@@ -85,13 +87,50 @@ export function applyStreamEvent(
           blocks: appendSessionBlock(message.blocks, {
             type: "tool_result",
             tool: pending?.tool ?? event.tool,
-            output: event.output,
-            run_id: event.run_id ?? event.tool,
+            output:
+              buffered.text.length > 0 && !event.output.includes(buffered.text)
+                ? buffered.text + event.output
+                : event.output,
+            run_id: runId,
             result: event.result,
+          }),
+          pendingTool: undefined,
+          toolChunkBuffers: buffered.next,
+        };
+      });
+    case "tool_awaiting_approval":
+      return updateStreamingMessage(state, event, (message) => {
+        const pending =
+          message.pendingTool?.runId === event.run_id
+            ? message.pendingTool
+            : null;
+        return {
+          ...message,
+          request_id: event.request_id ?? message.request_id,
+          blocks: appendSessionBlock(message.blocks, {
+            type: "approval_gate",
+            tool: pending?.tool ?? event.tool,
+            input: pending?.input ?? event.input,
+            run_id: event.run_id,
+            reason: event.reason,
+            message: event.message,
+            result: event.result,
+            policy: event.policy,
           }),
           pendingTool: undefined,
         };
       });
+    case "tool_chunk":
+      return updateStreamingMessage(state, event, (message) => ({
+        ...message,
+        request_id: event.request_id ?? message.request_id,
+        toolChunkBuffers: appendChunkToBuffer(
+          message.toolChunkBuffers,
+          event.run_id,
+          event.chunk_index,
+          event.chunk
+        ),
+      }));
     case "plan_created":
       return updateStreamingMessage(state, event, (message) => ({
         ...message,
@@ -318,6 +357,46 @@ function appendTextBlock(
     text: normalized,
   });
   return next;
+}
+
+interface ChunkBufferEntry {
+  chunks: { index: number; text: string }[];
+}
+
+export type ToolChunkBuffers = Record<string, ChunkBufferEntry>;
+
+function appendChunkToBuffer(
+  buffers: ToolChunkBuffers | undefined,
+  runId: string,
+  chunkIndex: number,
+  chunkText: string
+): ToolChunkBuffers {
+  const next: ToolChunkBuffers = { ...(buffers ?? {}) };
+  const existing = next[runId]?.chunks ?? [];
+  if (existing.some((entry) => entry.index === chunkIndex)) {
+    return next;
+  }
+  const merged = [...existing, { index: chunkIndex, text: chunkText }].sort(
+    (a, b) => a.index - b.index
+  );
+  next[runId] = { chunks: merged };
+  return next;
+}
+
+function takeChunkBuffer(
+  buffers: ToolChunkBuffers | undefined,
+  runId: string
+): { text: string; next: ToolChunkBuffers | undefined } {
+  if (!buffers || !buffers[runId]) {
+    return { text: "", next: buffers };
+  }
+  const text = buffers[runId].chunks.map((entry) => entry.text).join("");
+  const next: ToolChunkBuffers = { ...buffers };
+  delete next[runId];
+  return {
+    text,
+    next: Object.keys(next).length > 0 ? next : undefined,
+  };
 }
 
 function replaceRetrievalBlock(

--- a/frontend/src/lib/message-blocks.ts
+++ b/frontend/src/lib/message-blocks.ts
@@ -973,6 +973,7 @@ export function normalizeMessageContent(
       case "usage":
       case "plan":
       case "verification":
+      case "approval_gate":
         break;
     }
   });

--- a/frontend/src/lib/runtime-events.test.ts
+++ b/frontend/src/lib/runtime-events.test.ts
@@ -57,6 +57,24 @@ function minimalPayloadFor(eventType: string): Record<string, unknown> {
         output: "ok",
         run_id: "run-1",
       };
+    case "tool_awaiting_approval":
+      return {
+        type: "tool_awaiting_approval",
+        tool: "terminal",
+        input: "rm -rf /",
+        run_id: "run-2",
+        reason: "requires_approval",
+        message: "Approve this destructive command before it runs.",
+      };
+    case "tool_chunk":
+      return {
+        type: "tool_chunk",
+        tool: "terminal",
+        run_id: "run-2",
+        chunk_index: 0,
+        chunk: "partial output...",
+        terminal: false,
+      };
     case "plan_created":
       return {
         type: "plan_created",

--- a/frontend/src/lib/runtime-events.ts
+++ b/frontend/src/lib/runtime-events.ts
@@ -19,6 +19,8 @@ export const RUNTIME_EVENT_TYPES = [
   "token",
   "tool_start",
   "tool_end",
+  "tool_awaiting_approval",
+  "tool_chunk",
   "plan_created",
   "plan_updated",
   "verification_result",
@@ -96,6 +98,36 @@ const ToolEndRuntimeEventSchema = z
     run_id: z.string(),
     result: jsonObjectSchema.nullish(),
     policy: jsonObjectSchema.nullish(),
+  })
+  .strict();
+
+const ToolAwaitingApprovalRuntimeEventSchema = z
+  .object({
+    type: z.literal("tool_awaiting_approval"),
+    schema_version: schemaVersionField,
+    request_id: requestIdField,
+    event_index: eventIndexField,
+    tool: z.string(),
+    input: z.string(),
+    run_id: z.string(),
+    reason: z.string(),
+    message: z.string(),
+    result: jsonObjectSchema.nullish(),
+    policy: jsonObjectSchema.nullish(),
+  })
+  .strict();
+
+const ToolChunkRuntimeEventSchema = z
+  .object({
+    type: z.literal("tool_chunk"),
+    schema_version: schemaVersionField,
+    request_id: requestIdField,
+    event_index: eventIndexField,
+    tool: z.string(),
+    run_id: z.string(),
+    chunk_index: z.number().int().min(0),
+    chunk: z.string(),
+    terminal: z.boolean().default(false),
   })
   .strict();
 
@@ -187,6 +219,8 @@ export const RuntimeEventSchema = z.discriminatedUnion("type", [
   TokenRuntimeEventSchema,
   ToolStartRuntimeEventSchema,
   ToolEndRuntimeEventSchema,
+  ToolAwaitingApprovalRuntimeEventSchema,
+  ToolChunkRuntimeEventSchema,
   PlanCreatedRuntimeEventSchema,
   PlanUpdatedRuntimeEventSchema,
   VerificationResultRuntimeEventSchema,
@@ -206,6 +240,8 @@ export const RUNTIME_EVENT_SCHEMAS: Record<
   token: TokenRuntimeEventSchema,
   tool_start: ToolStartRuntimeEventSchema,
   tool_end: ToolEndRuntimeEventSchema,
+  tool_awaiting_approval: ToolAwaitingApprovalRuntimeEventSchema,
+  tool_chunk: ToolChunkRuntimeEventSchema,
   plan_created: PlanCreatedRuntimeEventSchema,
   plan_updated: PlanUpdatedRuntimeEventSchema,
   verification_result: VerificationResultRuntimeEventSchema,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -22,7 +22,8 @@ export interface ToolResultError {
     | "blocked"
     | "invalid_input"
     | "retriable_failure"
-    | "execution_failure";
+    | "execution_failure"
+    | "needs_approval";
   message: string;
   retriable: boolean;
 }
@@ -41,7 +42,9 @@ export interface ToolResultEnvelope {
     | "blocked"
     | "invalid_input"
     | "retriable_failure"
-    | "execution_failure";
+    | "execution_failure"
+    | "needs_approval"
+    | "streaming_chunk";
   error?: ToolResultError | null;
   metadata: JsonObject;
   source_payload?: JsonValue;
@@ -287,6 +290,27 @@ export interface ChatStreamToolEndEvent extends ChatStreamEventBase {
   policy?: JsonObject;
 }
 
+export interface ChatStreamToolAwaitingApprovalEvent
+  extends ChatStreamEventBase {
+  type: "tool_awaiting_approval";
+  tool: string;
+  input: string;
+  run_id: string;
+  reason: string;
+  message: string;
+  result?: ToolResultEnvelope;
+  policy?: JsonObject;
+}
+
+export interface ChatStreamToolChunkEvent extends ChatStreamEventBase {
+  type: "tool_chunk";
+  tool: string;
+  run_id: string;
+  chunk_index: number;
+  chunk: string;
+  terminal: boolean;
+}
+
 interface ChatStreamPlanEventBase extends ChatStreamEventBase {
   summary: string;
   run_id?: string;
@@ -349,6 +373,8 @@ export type ChatStreamEvent =
   | ChatStreamTokenEvent
   | ChatStreamToolStartEvent
   | ChatStreamToolEndEvent
+  | ChatStreamToolAwaitingApprovalEvent
+  | ChatStreamToolChunkEvent
   | ChatStreamPlanCreatedEvent
   | ChatStreamPlanUpdatedEvent
   | ChatStreamVerificationResultEvent
@@ -409,6 +435,17 @@ export interface SessionVerificationBlock {
   tool_trace?: JsonObject[];
 }
 
+export interface SessionApprovalGateBlock {
+  type: "approval_gate";
+  tool: string;
+  input: string;
+  run_id: string;
+  reason: string;
+  message: string;
+  result?: ToolResultEnvelope;
+  policy?: JsonObject;
+}
+
 export type SessionContentBlock =
   | SessionTextBlock
   | SessionToolUseBlock
@@ -416,7 +453,8 @@ export type SessionContentBlock =
   | SessionRetrievalBlock
   | SessionUsageBlock
   | SessionPlanBlock
-  | SessionVerificationBlock;
+  | SessionVerificationBlock
+  | SessionApprovalGateBlock;
 
 export interface Message {
   id: string;
@@ -429,6 +467,11 @@ export interface Message {
   endedAtMs?: number;
   /** Tool currently executing (cleared when tool_end arrives) */
   pendingTool?: { tool: string; input: string; runId: string };
+  /**
+   * Mid-tool partial outputs, keyed by run_id, accumulated until the matching
+   * `tool_end` arrives and the buffer is flushed into the persisted block.
+   */
+  toolChunkBuffers?: Record<string, { chunks: { index: number; text: string }[] }>;
 }
 
 export interface SessionHistoryMessage {


### PR DESCRIPTION
## Summary

Lays the typed-data-layer foundation for [#24](https://github.com/Azealoo/miniAgent/issues/24)'s discriminated tool-result union without refactoring every existing call site. Extends the flat `ToolResultEnvelope` with two new outcomes (`needs_approval`, `streaming_chunk`), adds matching SSE event types, and wires the policy wrapper to short-circuit on approval-gated tools so they never run silently.

- **Backend**: new outcomes/error code + helpers in `backend/tools/contracts.py`; `requires_approval` flag on `ToolPolicyMetadata`; `evaluate_pre_tool_policy` returns `needs_approval` for gated tools (`terminal`, `python_repl`, `write_file`) unless `ToolPolicyExecutionContext.approved_tool_runs` includes the tool; `policy_wrappers` mirrors the existing `blocked` short-circuit; `runtime/events.py` adds `tool_awaiting_approval` + `tool_chunk` (schema regenerated); `graph/agent.py` swaps `tool_end` for `tool_awaiting_approval` when the envelope is `needs_approval`.
- **Frontend**: zod mirrors + `RUNTIME_EVENT_TYPES` updated; `chat-stream-events.ts` parser handles both new variants; reducer appends a `SessionApprovalGateBlock` on approval, buffers per-`run_id` chunks and flushes them into the terminal `tool_result` block; `types.ts`/`api.ts` accept the new persisted block shape.
- **Tests**: backend covers each helper, the policy short-circuit, the approved-runs bypass, and both runtime-event payloads (drift-guard + JSON schema regenerated). Frontend covers the reducer's approval gate path and the chunk-buffer flush.

## What's intentionally not in this PR

These are non-trivial enough to deserve their own PRs and reviews:

- `POST /api/chat/{session_id}/approval` endpoint + runtime turn pause/resume that actually consumes `approved_tool_runs`.
- React component that renders the inline approval gate (the persisted `approval_gate` block shape is in place; `TurnActivityFeed` and `TurnDetailsPanel` will get a new arm).
- Wiring concrete tools (terminal/python_repl) to actually emit `tool_chunk` events during execution — chunk *transport* is plumbed end-to-end, but no tool produces chunks yet.

## Test plan

- [x] `cd backend && python -m pytest tests/test_runtime_events.py tests/test_tool_output_contracts.py tests/test_tool_policy.py tests/test_policy_wrapper_exceptions.py tests/test_audit_logging.py tests/test_chat_streaming.py tests/test_runtime_query_engine.py` — 252 passed (1 pre-existing `html2text` import failure unrelated to this change).
- [x] `cd frontend && npm run typecheck` — clean.
- [x] `cd frontend && npm test -- --run` — 107 passed.
- [x] `cd frontend && npm run lint` — clean.

https://claude.ai/code/session_01UnJnU9QiJiXGFurvG1ucg9