### PR TITLE
Add kind/scope/tags filtering to memory retrieval

### DIFF
--- a/backend/graph/memory_indexer.py
+++ b/backend/graph/memory_indexer.py
@@ -1,15 +1,19 @@
 import hashlib
+import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 from .memory_types import (
     ParsedMemoryDocument,
     TypedMemoryMetadata,
     display_memory_type,
+    infer_kind_from_source,
     parse_memory_document,
 )
+
+logger = logging.getLogger(__name__)
 
 _TEXT_MEMORY_SUFFIXES = {".md", ".markdown", ".txt"}
 _MARKDOWN_MEMORY_SUFFIXES = {".md", ".markdown"}
@@ -54,6 +58,24 @@ class _MemorySection:
     memory_type: str | None = None
     memory_name: str | None = None
     memory_description: str | None = None
+    memory_kind: str | None = None
+    memory_scope: str | None = None
+    memory_tags: tuple[str, ...] = ()
+
+
+def _normalize_filter_values(value: Any) -> set[str] | None:
+    """Coerce a single string or iterable of strings into a lowercase set; None -> no filter."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        token = value.strip().lower()
+        return {token} if token else None
+    try:
+        tokens = {str(item).strip().lower() for item in value}
+    except TypeError:
+        return None
+    tokens.discard("")
+    return tokens or None
 
 
 class MemoryIndexer:
@@ -134,8 +156,16 @@ class MemoryIndexer:
         document: ParsedMemoryDocument,
     ) -> list[_MemorySection]:
         suffix = Path(document.source).suffix.lower()
+        inferred_kind = infer_kind_from_source(document.source)
         if suffix not in _MARKDOWN_MEMORY_SUFFIXES:
-            return [self._build_section(document.source, document.body, document.metadata)]
+            return [
+                self._build_section(
+                    document.source,
+                    document.body,
+                    document.metadata,
+                    inferred_kind=inferred_kind,
+                )
+            ]
 
         raw_sections: list[_MemorySection] = []
         current_heading: str | None = None
@@ -152,7 +182,12 @@ class MemoryIndexer:
                 if anchor:
                     section_source = f"{document.source}#{anchor}"
             raw_sections.append(
-                self._build_section(section_source, text, document.metadata)
+                self._build_section(
+                    section_source,
+                    text,
+                    document.metadata,
+                    inferred_kind=inferred_kind,
+                )
             )
 
         for line in document.body.splitlines():
@@ -170,7 +205,14 @@ class MemoryIndexer:
         flush_current_section()
 
         if not raw_sections:
-            return [self._build_section(document.source, document.body, document.metadata)]
+            return [
+                self._build_section(
+                    document.source,
+                    document.body,
+                    document.metadata,
+                    inferred_kind=inferred_kind,
+                )
+            ]
 
         deduped_sections: list[_MemorySection] = []
         seen_sources: dict[str, int] = {}
@@ -178,21 +220,26 @@ class MemoryIndexer:
             occurrence = seen_sources.get(section.source, 0) + 1
             seen_sources[section.source] = occurrence
             if occurrence > 1:
+                metadata_copy: TypedMemoryMetadata | None = None
+                if (
+                    section.memory_type is not None
+                    and section.memory_name is not None
+                    and section.memory_description is not None
+                ):
+                    metadata_copy = TypedMemoryMetadata(
+                        memory_type=section.memory_type,
+                        name=section.memory_name,
+                        description=section.memory_description,
+                        kind=section.memory_kind,
+                        scope=section.memory_scope,
+                        tags=section.memory_tags,
+                    )
                 deduped_sections.append(
                     self._build_section(
                         f"{section.source}-{occurrence}",
                         section.text,
-                        TypedMemoryMetadata(
-                            memory_type=section.memory_type,
-                            name=section.memory_name,
-                            description=section.memory_description,
-                        )
-                        if (
-                            section.memory_type is not None
-                            and section.memory_name is not None
-                            and section.memory_description is not None
-                        )
-                        else None,
+                        metadata_copy,
+                        inferred_kind=inferred_kind,
                     )
                 )
                 continue
@@ -215,16 +262,25 @@ class MemoryIndexer:
         source: str,
         text: str,
         metadata: TypedMemoryMetadata | None,
+        *,
+        inferred_kind: str | None = None,
     ) -> _MemorySection:
         search_parts = [source.lower(), self._normalize_text(text)]
         memory_type: str | None = None
         memory_name: str | None = None
         memory_description: str | None = None
+        memory_kind: str | None = inferred_kind
+        memory_scope: str | None = None
+        memory_tags: tuple[str, ...] = ()
 
         if metadata is not None:
             memory_type = metadata.memory_type
             memory_name = metadata.name
             memory_description = metadata.description
+            if metadata.kind:
+                memory_kind = metadata.kind
+            memory_scope = metadata.scope
+            memory_tags = metadata.tags
             search_parts.extend(
                 [
                     metadata.memory_type,
@@ -233,6 +289,8 @@ class MemoryIndexer:
                     self._normalize_text(metadata.description),
                 ]
             )
+            if memory_tags:
+                search_parts.append(" ".join(memory_tags))
 
         return _MemorySection(
             source=source,
@@ -241,6 +299,9 @@ class MemoryIndexer:
             memory_type=memory_type,
             memory_name=memory_name,
             memory_description=memory_description,
+            memory_kind=memory_kind,
+            memory_scope=memory_scope,
+            memory_tags=memory_tags,
         )
 
     def _normalize_text(self, text: str) -> str:
@@ -252,6 +313,9 @@ class MemoryIndexer:
         memory_type: str | None,
         memory_name: str | None,
         memory_description: str | None,
+        memory_kind: str | None = None,
+        memory_scope: str | None = None,
+        memory_tags: tuple[str, ...] | list[str] | None = None,
     ) -> dict[str, Any]:
         fields: dict[str, Any] = {}
         if memory_type:
@@ -261,7 +325,57 @@ class MemoryIndexer:
             fields["memory_name"] = memory_name
         if memory_description:
             fields["memory_description"] = memory_description
+        if memory_kind:
+            fields["memory_kind"] = memory_kind
+        if memory_scope:
+            fields["memory_scope"] = memory_scope
+        if memory_tags:
+            fields["memory_tags"] = list(memory_tags)
         return fields
+
+    def _section_matches_filters(
+        self,
+        section_kind: str | None,
+        section_scope: str | None,
+        section_tags: Iterable[str],
+        *,
+        kind_filter: set[str] | None,
+        scope_filter: set[str] | None,
+        tag_filter: set[str] | None,
+    ) -> bool:
+        if kind_filter is not None:
+            if not section_kind or section_kind not in kind_filter:
+                return False
+        if scope_filter is not None:
+            if not section_scope or section_scope not in scope_filter:
+                return False
+        if tag_filter is not None:
+            section_tag_set = {tag.lower() for tag in section_tags or ()}
+            if not section_tag_set.intersection(tag_filter):
+                return False
+        return True
+
+    def _result_matches_filters(
+        self,
+        result: dict[str, Any],
+        *,
+        kind_filter: set[str] | None,
+        scope_filter: set[str] | None,
+        tag_filter: set[str] | None,
+    ) -> bool:
+        section_kind = result.get("memory_kind")
+        if section_kind is None:
+            section_kind = infer_kind_from_source(str(result.get("source", "")))
+        tags_value = result.get("memory_tags")
+        section_tags: Iterable[str] = tags_value if isinstance(tags_value, list) else ()
+        return self._section_matches_filters(
+            section_kind,
+            result.get("memory_scope"),
+            section_tags,
+            kind_filter=kind_filter,
+            scope_filter=scope_filter,
+            tag_filter=tag_filter,
+        )
 
     def _summarize_text(self, text: str) -> str:
         normalized = " ".join(text.split()).strip()
@@ -283,7 +397,15 @@ class MemoryIndexer:
             terms.append(token)
         return terms
 
-    def _lexical_results(self, query: str, top_k: int) -> list[dict]:
+    def _lexical_results(
+        self,
+        query: str,
+        top_k: int,
+        *,
+        kind_filter: set[str] | None = None,
+        scope_filter: set[str] | None = None,
+        tag_filter: set[str] | None = None,
+    ) -> list[dict]:
         terms = self._query_terms(query)
         if not terms:
             return []
@@ -291,6 +413,15 @@ class MemoryIndexer:
         scored_results: list[dict[str, Any]] = []
         phrase = " ".join(terms)
         for section in self._sections:
+            if not self._section_matches_filters(
+                section.memory_kind,
+                section.memory_scope,
+                section.memory_tags,
+                kind_filter=kind_filter,
+                scope_filter=scope_filter,
+                tag_filter=tag_filter,
+            ):
+                continue
             matched_terms = [term for term in terms if term in section.search_text]
             if not matched_terms:
                 continue
@@ -309,6 +440,9 @@ class MemoryIndexer:
                         memory_type=section.memory_type,
                         memory_name=section.memory_name,
                         memory_description=section.memory_description,
+                        memory_kind=section.memory_kind,
+                        memory_scope=section.memory_scope,
+                        memory_tags=section.memory_tags,
                     ),
                 }
             )
@@ -346,6 +480,25 @@ class MemoryIndexer:
     # Public API                                                           #
     # ------------------------------------------------------------------ #
 
+    def _log_malformed_documents(self) -> None:
+        """
+        Walk memory/ at rebuild time and log any files with malformed typed-memory
+        frontmatter. The backend keeps booting — misconfigured files are skipped
+        from typed-section indexing but their body text is still retrievable.
+        """
+        for path in self._memory_files():
+            try:
+                content = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            parsed = parse_memory_document(self._relative_source(path), content)
+            if parsed.errors:
+                logger.warning(
+                    "Malformed typed memory file %s: %s",
+                    parsed.source,
+                    "; ".join(parsed.errors),
+                )
+
     def rebuild_index(self) -> None:
         """
         Build a VectorStoreIndex from memory/ documents and persist to storage/memory_index/.
@@ -355,6 +508,8 @@ class MemoryIndexer:
         """
         current_md5 = self._memory_state_md5()
         md5_file = self._storage_path / "md5.txt"
+
+        self._log_malformed_documents()
 
         sections = self._memory_sections()
         self._sections = sections
@@ -404,6 +559,12 @@ class MemoryIndexer:
                 metadata["memory_name"] = section.memory_name
             if section.memory_description:
                 metadata["memory_description"] = section.memory_description
+            if section.memory_kind:
+                metadata["memory_kind"] = section.memory_kind
+            if section.memory_scope:
+                metadata["memory_scope"] = section.memory_scope
+            if section.memory_tags:
+                metadata["memory_tags"] = list(section.memory_tags)
             docs.append(Document(text=section.text, metadata=metadata))
         splitter = SentenceSplitter(chunk_size=256, chunk_overlap=32)
         self._nodes = splitter.get_nodes_from_documents(docs)
@@ -420,17 +581,44 @@ class MemoryIndexer:
                 # block lexical/BM25 memory retrieval for the current turn.
                 self._index = None
 
-    def retrieve(self, query: str, top_k: int = 3) -> list[dict]:
+    def retrieve(
+        self,
+        query: str,
+        top_k: int = 3,
+        *,
+        kind: str | Iterable[str] | None = None,
+        scope: str | Iterable[str] | None = None,
+        tags: str | Iterable[str] | None = None,
+    ) -> list[dict]:
         """
         Hybrid BM25 + vector retrieval.
-        Returns [{text, score, source}, ...] deduplicated, up to top_k results.
+
+        Results are deduplicated by source and returned up to top_k, sorted by score.
+        Each result dict carries typed-memory fields when the source has frontmatter:
+        `memory_type`, `memory_type_label`, `memory_name`, `memory_description`,
+        `memory_kind`, `memory_scope`, `memory_tags`.
+
+        Optional filters (all default to no filtering):
+          * `kind` — one of or an iterable over {'project', 'user', 'agent'}.
+          * `scope` — one of or an iterable over {'session', 'project', 'user', 'global'}.
+          * `tags` — one tag or an iterable of tags; a section matches when its tag set
+            intersects the filter set.
         """
         self._maybe_rebuild()
 
         if not self._sections and (self._index is None or not self._nodes):
             return []
 
+        kind_filter = _normalize_filter_values(kind)
+        scope_filter = _normalize_filter_values(scope)
+        tag_filter = _normalize_filter_values(tags)
+
         results_by_source: dict[str, dict[str, Any]] = {}
+
+        def _coerce_tag_list(raw: Any) -> list[str]:
+            if isinstance(raw, list):
+                return [str(item) for item in raw if str(item).strip()]
+            return []
 
         def remember_result(
             text: str,
@@ -440,18 +628,37 @@ class MemoryIndexer:
             memory_type: str | None = None,
             memory_name: str | None = None,
             memory_description: str | None = None,
+            memory_kind: str | None = None,
+            memory_scope: str | None = None,
+            memory_tags: tuple[str, ...] | list[str] | None = None,
         ) -> None:
             if not source:
                 return
             summarized_text = self._summarize_text(text)
             if not summarized_text:
                 return
+
+            effective_kind = memory_kind or infer_kind_from_source(source)
+            tag_list = list(memory_tags or ())
+            if not self._section_matches_filters(
+                effective_kind,
+                memory_scope,
+                tag_list,
+                kind_filter=kind_filter,
+                scope_filter=scope_filter,
+                tag_filter=tag_filter,
+            ):
+                return
+
             existing = results_by_source.get(source)
             normalized_score = float(score or 0.0)
             typed_fields = self._typed_result_fields(
                 memory_type=memory_type,
                 memory_name=memory_name,
                 memory_description=memory_description,
+                memory_kind=effective_kind,
+                memory_scope=memory_scope,
+                memory_tags=tag_list,
             )
             if existing is not None and normalized_score <= float(existing["score"]):
                 if typed_fields and not all(key in existing for key in typed_fields):
@@ -469,6 +676,36 @@ class MemoryIndexer:
                         updated_result[key] = value
             results_by_source[source] = updated_result
 
+        def _node_kwargs(node_metadata: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "memory_type": (
+                    str(node_metadata["memory_type"])
+                    if node_metadata.get("memory_type")
+                    else None
+                ),
+                "memory_name": (
+                    str(node_metadata["memory_name"])
+                    if node_metadata.get("memory_name")
+                    else None
+                ),
+                "memory_description": (
+                    str(node_metadata["memory_description"])
+                    if node_metadata.get("memory_description")
+                    else None
+                ),
+                "memory_kind": (
+                    str(node_metadata["memory_kind"])
+                    if node_metadata.get("memory_kind")
+                    else None
+                ),
+                "memory_scope": (
+                    str(node_metadata["memory_scope"])
+                    if node_metadata.get("memory_scope")
+                    else None
+                ),
+                "memory_tags": _coerce_tag_list(node_metadata.get("memory_tags")),
+            }
+
         # Vector retrieval
         if self._index is not None and self._nodes:
             try:
@@ -478,21 +715,7 @@ class MemoryIndexer:
                         node.text,
                         float(node.score or 0.0),
                         str(node.metadata.get("source", "memory/MEMORY.md")),
-                        memory_type=(
-                            str(node.metadata["memory_type"])
-                            if node.metadata.get("memory_type")
-                            else None
-                        ),
-                        memory_name=(
-                            str(node.metadata["memory_name"])
-                            if node.metadata.get("memory_name")
-                            else None
-                        ),
-                        memory_description=(
-                            str(node.metadata["memory_description"])
-                            if node.metadata.get("memory_description")
-                            else None
-                        ),
+                        **_node_kwargs(node.metadata),
                     )
             except Exception:
                 pass
@@ -508,26 +731,18 @@ class MemoryIndexer:
                         node.text,
                         float(node.score or 0.0),
                         str(node.metadata.get("source", "memory/MEMORY.md")),
-                        memory_type=(
-                            str(node.metadata["memory_type"])
-                            if node.metadata.get("memory_type")
-                            else None
-                        ),
-                        memory_name=(
-                            str(node.metadata["memory_name"])
-                            if node.metadata.get("memory_name")
-                            else None
-                        ),
-                        memory_description=(
-                            str(node.metadata["memory_description"])
-                            if node.metadata.get("memory_description")
-                            else None
-                        ),
+                        **_node_kwargs(node.metadata),
                     )
             except Exception:
                 pass
 
-        for result in self._lexical_results(query, top_k=max(top_k * 2, top_k)):
+        for result in self._lexical_results(
+            query,
+            top_k=max(top_k * 2, top_k),
+            kind_filter=kind_filter,
+            scope_filter=scope_filter,
+            tag_filter=tag_filter,
+        ):
             remember_result(
                 str(result["text"]),
                 float(result["score"]),
@@ -547,6 +762,17 @@ class MemoryIndexer:
                     if result.get("memory_description")
                     else None
                 ),
+                memory_kind=(
+                    str(result["memory_kind"])
+                    if result.get("memory_kind")
+                    else None
+                ),
+                memory_scope=(
+                    str(result["memory_scope"])
+                    if result.get("memory_scope")
+                    else None
+                ),
+                memory_tags=_coerce_tag_list(result.get("memory_tags")),
             )
 
         # Return up to top_k, sorted by score descending

--- a/backend/graph/memory_indexer.py
+++ b/backend/graph/memory_indexer.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable, Optional
 from .memory_types import (
     ParsedMemoryDocument,
     TypedMemoryMetadata,
+    default_scope_for_kind,
     display_memory_type,
     infer_kind_from_source,
     parse_memory_document,
@@ -292,6 +293,12 @@ class MemoryIndexer:
             if memory_tags:
                 search_parts.append(" ".join(memory_tags))
 
+        # Legacy files with no frontmatter still belong to a kind (by directory).
+        # Give them the matching default scope so `retrieve(scope=kind)` behaves
+        # the same for legacy and typed files.
+        if memory_scope is None and memory_kind:
+            memory_scope = default_scope_for_kind(memory_kind)
+
         return _MemorySection(
             source=source,
             text=text,
@@ -354,28 +361,6 @@ class MemoryIndexer:
             if not section_tag_set.intersection(tag_filter):
                 return False
         return True
-
-    def _result_matches_filters(
-        self,
-        result: dict[str, Any],
-        *,
-        kind_filter: set[str] | None,
-        scope_filter: set[str] | None,
-        tag_filter: set[str] | None,
-    ) -> bool:
-        section_kind = result.get("memory_kind")
-        if section_kind is None:
-            section_kind = infer_kind_from_source(str(result.get("source", "")))
-        tags_value = result.get("memory_tags")
-        section_tags: Iterable[str] = tags_value if isinstance(tags_value, list) else ()
-        return self._section_matches_filters(
-            section_kind,
-            result.get("memory_scope"),
-            section_tags,
-            kind_filter=kind_filter,
-            scope_filter=scope_filter,
-            tag_filter=tag_filter,
-        )
 
     def _summarize_text(self, text: str) -> str:
         normalized = " ".join(text.split()).strip()
@@ -639,10 +624,11 @@ class MemoryIndexer:
                 return
 
             effective_kind = memory_kind or infer_kind_from_source(source)
+            effective_scope = memory_scope or default_scope_for_kind(effective_kind)
             tag_list = list(memory_tags or ())
             if not self._section_matches_filters(
                 effective_kind,
-                memory_scope,
+                effective_scope,
                 tag_list,
                 kind_filter=kind_filter,
                 scope_filter=scope_filter,
@@ -657,7 +643,7 @@ class MemoryIndexer:
                 memory_name=memory_name,
                 memory_description=memory_description,
                 memory_kind=effective_kind,
-                memory_scope=memory_scope,
+                memory_scope=effective_scope,
                 memory_tags=tag_list,
             )
             if existing is not None and normalized_score <= float(existing["score"]):

--- a/backend/graph/memory_types.py
+++ b/backend/graph/memory_types.py
@@ -117,6 +117,13 @@ def infer_kind_from_source(source: str) -> str | None:
     return candidate if candidate in TYPED_MEMORY_KIND_VALUES else None
 
 
+def default_scope_for_kind(kind: str | None) -> str | None:
+    """Map a `kind` value to its default `scope` (agent->global, else identity). Unknown -> None."""
+    if not kind:
+        return None
+    return _DEFAULT_SCOPE_FOR_KIND.get(kind)
+
+
 def _coerce_tags(raw_value: Any) -> tuple[tuple[str, ...], str | None]:
     """Return (normalized_tags, error). Missing value -> ((), None)."""
     if raw_value is None:

--- a/backend/graph/memory_types.py
+++ b/backend/graph/memory_types.py
@@ -1,3 +1,41 @@
+"""
+Typed memory document schema.
+
+Every markdown file under backend/memory/{project,user,agent}/ may carry a YAML
+frontmatter block. When present, the block must satisfy this schema:
+
+    ---
+    type: <one of TYPED_MEMORY_TYPE_VALUES>     # required
+    name: <human-readable short title>           # required, non-empty
+    description: <one-line summary>              # required, non-empty
+    kind: project | user | agent                 # optional; inferred from path
+    scope: session | project | user | global     # optional; defaults by kind
+    tags: [tag-a, tag-b]                         # optional flat list of strings
+    pinned: true | false                         # optional; default false
+    updated_at: 2026-04-17T00:00:00Z             # optional ISO-8601
+    ---
+
+Semantics:
+
+    * `type`  — fine-grained taxonomy used by retrieval labelling and
+      distillation routing. One of TYPED_MEMORY_TYPE_VALUES.
+    * `kind`  — coarse axis aligned with the on-disk layout. When omitted,
+      it is inferred from the directory: memory/project/... -> 'project',
+      memory/user/... -> 'user', memory/agent/... -> 'agent'.
+    * `scope` — applicability. Defaults track `kind` (project->project,
+      user->user, agent->global). `session` denotes a scratch-pad tied to
+      the originating session.
+    * `tags`  — freeform, flat, lowercase tokens. No controlled vocabulary.
+    * `pinned` / `updated_at` — already consumed by the scoped-memory listing
+      in prompt_builder.py; now also carried on parsed metadata for symmetry
+      and so that `validate_memory_write` / retrieval filters can reason
+      about them.
+
+Files without frontmatter remain valid (legacy notes); they are just excluded
+from typed filtering. Malformed frontmatter is rejected by
+`validate_memory_write` on every write, and logged (not fatal) by the
+MemoryIndexer at startup rebuild so the backend still boots.
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -13,8 +51,19 @@ TYPED_MEMORY_TYPE_VALUES = (
     "scientific_reference",
     "session_distillation",
 )
+
+TYPED_MEMORY_KIND_VALUES = ("project", "user", "agent")
+TYPED_MEMORY_SCOPE_VALUES = ("session", "project", "user", "global")
+
 _MARKDOWN_MEMORY_SUFFIXES = {".md", ".markdown"}
 _TYPED_MEMORY_REQUIRED_FIELDS = ("type", "name", "description")
+
+# kind -> default scope when scope is omitted
+_DEFAULT_SCOPE_FOR_KIND = {
+    "project": "project",
+    "user": "user",
+    "agent": "global",
+}
 
 
 @dataclass(frozen=True)
@@ -22,6 +71,11 @@ class TypedMemoryMetadata:
     memory_type: str
     name: str
     description: str
+    kind: str | None = None
+    scope: str | None = None
+    tags: tuple[str, ...] = ()
+    pinned: bool = False
+    updated_at: str | None = None
 
 
 @dataclass(frozen=True)
@@ -46,6 +100,70 @@ def normalize_memory_type(raw_value: Any) -> str:
         return ""
     normalized = " ".join(str(raw_value).strip().lower().replace("-", " ").split())
     return normalized.replace(" ", "_")
+
+
+def _normalize_enum_value(raw_value: Any) -> str:
+    if raw_value is None:
+        return ""
+    return str(raw_value).strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def infer_kind_from_source(source: str) -> str | None:
+    """Infer `kind` from a memory file's relative path, e.g. memory/project/... -> 'project'."""
+    parts = Path(source).parts
+    if len(parts) < 2 or parts[0] != "memory":
+        return None
+    candidate = parts[1]
+    return candidate if candidate in TYPED_MEMORY_KIND_VALUES else None
+
+
+def _coerce_tags(raw_value: Any) -> tuple[tuple[str, ...], str | None]:
+    """Return (normalized_tags, error). Missing value -> ((), None)."""
+    if raw_value is None:
+        return (), None
+    if isinstance(raw_value, str):
+        return (), "Typed memory frontmatter `tags` must be a list of strings, not a string."
+    if not isinstance(raw_value, list):
+        return (), "Typed memory frontmatter `tags` must be a list of strings."
+    cleaned: list[str] = []
+    for item in raw_value:
+        if not isinstance(item, str):
+            return (), "Typed memory frontmatter `tags` must be a list of strings."
+        token = item.strip().lower()
+        if token and token not in cleaned:
+            cleaned.append(token)
+    return tuple(cleaned), None
+
+
+def _coerce_pinned(raw_value: Any) -> tuple[bool, str | None]:
+    if raw_value is None:
+        return False, None
+    if isinstance(raw_value, bool):
+        return raw_value, None
+    return False, "Typed memory frontmatter `pinned` must be a boolean."
+
+
+def _coerce_updated_at(raw_value: Any) -> tuple[str | None, str | None]:
+    from datetime import date, datetime
+
+    if raw_value is None:
+        return None, None
+    # PyYAML decodes bare ISO timestamps to datetime/date; accept and stringify.
+    if isinstance(raw_value, datetime):
+        return raw_value.isoformat(), None
+    if isinstance(raw_value, date):
+        return raw_value.isoformat(), None
+    if not isinstance(raw_value, str):
+        return None, "Typed memory frontmatter `updated_at` must be an ISO-8601 string."
+    value = raw_value.strip()
+    if not value:
+        return None, None
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        datetime.fromisoformat(normalized)
+    except ValueError:
+        return None, "Typed memory frontmatter `updated_at` must be an ISO-8601 string."
+    return value, None
 
 
 def _split_markdown_frontmatter(
@@ -97,9 +215,10 @@ def parse_memory_document(source: str, content: str) -> ParsedMemoryDocument:
     metadata: TypedMemoryMetadata | None = None
     if frontmatter_present and not errors:
         missing_fields = [
-            field
-            for field in _TYPED_MEMORY_REQUIRED_FIELDS
-            if frontmatter.get(field) is None or not str(frontmatter.get(field, "")).strip()
+            field_name
+            for field_name in _TYPED_MEMORY_REQUIRED_FIELDS
+            if frontmatter.get(field_name) is None
+            or not str(frontmatter.get(field_name, "")).strip()
         ]
         if missing_fields:
             errors.append(
@@ -116,11 +235,59 @@ def parse_memory_document(source: str, content: str) -> ParsedMemoryDocument:
                     + "."
                 )
             else:
-                metadata = TypedMemoryMetadata(
-                    memory_type=memory_type,
-                    name=str(frontmatter["name"]).strip(),
-                    description=str(frontmatter["description"]).strip(),
+                kind_raw = frontmatter.get("kind")
+                kind: str | None
+                if kind_raw is None:
+                    kind = infer_kind_from_source(source)
+                else:
+                    kind = _normalize_enum_value(kind_raw)
+                    if kind not in TYPED_MEMORY_KIND_VALUES:
+                        errors.append(
+                            "Typed memory frontmatter `kind` must be one of: "
+                            + ", ".join(TYPED_MEMORY_KIND_VALUES)
+                            + "."
+                        )
+                        kind = None
+
+                scope_raw = frontmatter.get("scope")
+                scope: str | None
+                if scope_raw is None:
+                    scope = _DEFAULT_SCOPE_FOR_KIND.get(kind) if kind else None
+                else:
+                    scope = _normalize_enum_value(scope_raw)
+                    if scope not in TYPED_MEMORY_SCOPE_VALUES:
+                        errors.append(
+                            "Typed memory frontmatter `scope` must be one of: "
+                            + ", ".join(TYPED_MEMORY_SCOPE_VALUES)
+                            + "."
+                        )
+                        scope = None
+
+                tags, tags_error = _coerce_tags(frontmatter.get("tags"))
+                if tags_error:
+                    errors.append(tags_error)
+
+                pinned, pinned_error = _coerce_pinned(frontmatter.get("pinned"))
+                if pinned_error:
+                    errors.append(pinned_error)
+
+                updated_at, updated_at_error = _coerce_updated_at(
+                    frontmatter.get("updated_at")
                 )
+                if updated_at_error:
+                    errors.append(updated_at_error)
+
+                if not errors:
+                    metadata = TypedMemoryMetadata(
+                        memory_type=memory_type,
+                        name=str(frontmatter["name"]).strip(),
+                        description=str(frontmatter["description"]).strip(),
+                        kind=kind,
+                        scope=scope,
+                        tags=tags,
+                        pinned=pinned,
+                        updated_at=updated_at,
+                    )
 
     return ParsedMemoryDocument(
         source=source,

--- a/backend/memory/project/rnaseq-de-readiness-review.md
+++ b/backend/memory/project/rnaseq-de-readiness-review.md
@@ -2,6 +2,9 @@
 type: workflow_heuristic
 name: RNA-seq differential expression readiness review template
 description: Structured readiness checklist for bulk RNA-seq differential expression work covering design inputs, inspectable files, governance, and go/no-go criteria.
+kind: project
+scope: project
+tags: [rnaseq, differential-expression, readiness-review]
 ---
 # RNA-seq Differential Expression Readiness Review
 

--- a/backend/memory/project/shared-paths.md
+++ b/backend/memory/project/shared-paths.md
@@ -2,6 +2,9 @@
 type: project_fact
 name: Shared BioAPEX paths and runtime defaults
 description: Durable filesystem locations and local runtime defaults that frequently matter during project work.
+kind: project
+scope: project
+tags: [paths, runtime, environment]
 ---
 # Paths
 

--- a/backend/memory/project/western-blot-buffer-scaling.md
+++ b/backend/memory/project/western-blot-buffer-scaling.md
@@ -2,6 +2,9 @@
 type: workflow_heuristic
 name: Glycine-limited Western blot running buffer scaling
 description: Practical scaling rule for the 10x running-buffer recipe when glycine is limited and round-number volumes are preferred.
+kind: project
+scope: project
+tags: [western-blot, buffer, protocol]
 ---
 # Original Recipe
 

--- a/backend/memory/user/johnny-preferences.md
+++ b/backend/memory/user/johnny-preferences.md
@@ -2,6 +2,9 @@
 type: user_preference
 name: Johnny collaboration preferences
 description: Stable user preferences, collaboration context, and recurring lab focus for BioAPEX sessions.
+kind: user
+scope: user
+tags: [preferences, collaboration]
 ---
 # Summary
 

--- a/backend/tests/test_memory_indexer.py
+++ b/backend/tests/test_memory_indexer.py
@@ -594,6 +594,33 @@ class TestRetrieve:
         assert results
         assert all("brca1" in (result.get("memory_tags") or []) for result in results)
 
+    def test_retrieve_scope_defaults_match_kind_for_legacy_files(self, indexer, tmp_path):
+        """Legacy files (no frontmatter) should still match scope filters that
+        correspond to their directory-inferred kind. Otherwise typed and legacy
+        files would behave inconsistently under the same scope filter."""
+        _write_memory_file(
+            tmp_path,
+            "memory/project/legacy-note.md",
+            "# Legacy\nBRCA1 legacy note content.\n",
+        )
+        _write_memory_file(
+            tmp_path,
+            "memory/user/legacy-pref.md",
+            "# Legacy\nBRCA1 legacy user preference content.\n",
+        )
+
+        project_results = indexer.retrieve("BRCA1 legacy", top_k=5, scope="project")
+        user_results = indexer.retrieve("BRCA1 legacy", top_k=5, scope="user")
+
+        assert any(
+            r["source"].startswith("memory/project/legacy-note.md")
+            for r in project_results
+        )
+        assert any(
+            r["source"].startswith("memory/user/legacy-pref.md")
+            for r in user_results
+        )
+
     def test_retrieve_returns_empty_when_filter_excludes_all(self, indexer, tmp_path):
         self._seed_kind_scope_corpus(tmp_path)
 

--- a/backend/tests/test_memory_indexer.py
+++ b/backend/tests/test_memory_indexer.py
@@ -14,7 +14,10 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from graph.memory_indexer import MemoryIndexer
 from graph.memory_types import (
+    TYPED_MEMORY_KIND_VALUES,
+    TYPED_MEMORY_SCOPE_VALUES,
     TYPED_MEMORY_TYPE_VALUES,
+    infer_kind_from_source,
     parse_memory_document,
     validate_memory_write,
 )
@@ -181,6 +184,138 @@ class TestTypedMemoryContract:
         )
 
 
+class TestTypedMemorySchemaExtensions:
+    """Schema coverage for kind / scope / tags / pinned / updated_at."""
+
+    def _base_frontmatter(self, **extra: str) -> str:
+        fields = {
+            "type": "project_fact",
+            "name": "Artifact runbook",
+            "description": "Keeps the artifact storage rule in one scoped note.",
+        }
+        fields.update(extra)
+        lines = ["---"]
+        for key, value in fields.items():
+            lines.append(f"{key}: {value}")
+        lines.extend(["---", "Keep outputs under artifacts/."])
+        return "\n".join(lines) + "\n"
+
+    def test_kind_inferred_from_project_directory(self):
+        parsed = parse_memory_document(
+            "memory/project/runbook.md", self._base_frontmatter()
+        )
+        assert parsed.metadata is not None
+        assert parsed.metadata.kind == "project"
+        # Scope defaults track kind.
+        assert parsed.metadata.scope == "project"
+
+    def test_kind_inferred_from_user_directory_defaults_scope_user(self):
+        parsed = parse_memory_document(
+            "memory/user/preferences.md",
+            self._base_frontmatter(type="user_preference"),
+        )
+        assert parsed.metadata is not None
+        assert parsed.metadata.kind == "user"
+        assert parsed.metadata.scope == "user"
+
+    def test_kind_inferred_from_agent_directory_defaults_scope_global(self):
+        parsed = parse_memory_document(
+            "memory/agent/policy.md",
+            self._base_frontmatter(type="workflow_heuristic"),
+        )
+        assert parsed.metadata is not None
+        assert parsed.metadata.kind == "agent"
+        assert parsed.metadata.scope == "global"
+
+    def test_explicit_scope_overrides_default(self):
+        parsed = parse_memory_document(
+            "memory/project/note.md", self._base_frontmatter(scope="session")
+        )
+        assert parsed.metadata is not None
+        assert parsed.metadata.scope == "session"
+
+    def test_explicit_kind_overrides_inferred_path(self):
+        parsed = parse_memory_document(
+            "memory/project/note.md", self._base_frontmatter(kind="user")
+        )
+        assert parsed.metadata is not None
+        assert parsed.metadata.kind == "user"
+
+    def test_invalid_kind_produces_validation_error(self):
+        errors = validate_memory_write(
+            "memory/project/note.md", self._base_frontmatter(kind="weird")
+        )
+        assert errors == (
+            "Typed memory frontmatter `kind` must be one of: "
+            + ", ".join(TYPED_MEMORY_KIND_VALUES)
+            + ".",
+        )
+
+    def test_invalid_scope_produces_validation_error(self):
+        errors = validate_memory_write(
+            "memory/project/note.md", self._base_frontmatter(scope="forever")
+        )
+        assert errors == (
+            "Typed memory frontmatter `scope` must be one of: "
+            + ", ".join(TYPED_MEMORY_SCOPE_VALUES)
+            + ".",
+        )
+
+    def test_tags_normalize_to_lowercase_deduplicated_tuple(self):
+        content = (
+            "---\n"
+            "type: project_fact\n"
+            "name: Tagged fact\n"
+            "description: Something tagged.\n"
+            "tags: [RNAseq, rnaseq, QC]\n"
+            "---\n"
+            "Body\n"
+        )
+        parsed = parse_memory_document("memory/project/tagged.md", content)
+        assert parsed.metadata is not None
+        assert parsed.metadata.tags == ("rnaseq", "qc")
+
+    def test_tags_must_be_a_list_not_a_string(self):
+        errors = validate_memory_write(
+            "memory/project/note.md", self._base_frontmatter(tags="rnaseq")
+        )
+        assert errors == (
+            "Typed memory frontmatter `tags` must be a list of strings, not a string.",
+        )
+
+    def test_pinned_must_be_boolean(self):
+        errors = validate_memory_write(
+            "memory/project/note.md", self._base_frontmatter(pinned="\"maybe\"")
+        )
+        assert errors == (
+            "Typed memory frontmatter `pinned` must be a boolean.",
+        )
+
+    def test_updated_at_must_be_iso_8601(self):
+        errors = validate_memory_write(
+            "memory/project/note.md", self._base_frontmatter(updated_at="last tuesday")
+        )
+        assert errors == (
+            "Typed memory frontmatter `updated_at` must be an ISO-8601 string.",
+        )
+
+    def test_updated_at_accepts_iso_timestamp(self):
+        parsed = parse_memory_document(
+            "memory/project/note.md",
+            self._base_frontmatter(updated_at="2026-04-17T00:00:00Z"),
+        )
+        assert parsed.metadata is not None
+        # PyYAML decodes ISO timestamps to datetime; we preserve the isoformat string.
+        assert parsed.metadata.updated_at == "2026-04-17T00:00:00+00:00"
+
+    def test_infer_kind_from_source_returns_none_outside_memory_tree(self):
+        assert infer_kind_from_source("workspace/SOUL.md") is None
+        assert infer_kind_from_source("memory/MEMORY.md") is None
+        assert infer_kind_from_source("memory/project/x.md") == "project"
+        assert infer_kind_from_source("memory/user/x.md") == "user"
+        assert infer_kind_from_source("memory/agent/x.md") == "agent"
+
+
 class TestMemoryStateMd5:
     def test_md5_missing_files_returns_empty(self, indexer):
         assert indexer._memory_state_md5() == ""
@@ -226,6 +361,47 @@ class TestRebuildIndexEdgeCases:
             pass
 
         assert indexer._last_md5 == expected_md5
+
+
+class TestStartupMalformedLogging:
+    def test_rebuild_index_logs_malformed_typed_memory_files(
+        self, indexer, tmp_path, caplog
+    ):
+        _write_memory_file(
+            tmp_path,
+            "memory/project/broken.md",
+            (
+                "---\n"
+                "type: unsupported type\n"
+                "name: Broken\n"
+                "description: Wrong type value.\n"
+                "---\n"
+                "Body\n"
+            ),
+        )
+        _write_memory_file(
+            tmp_path,
+            "memory/project/ok.md",
+            (
+                "---\n"
+                "type: project_fact\n"
+                "name: OK note\n"
+                "description: Healthy frontmatter.\n"
+                "---\n"
+                "Body\n"
+            ),
+        )
+
+        with caplog.at_level("WARNING", logger="graph.memory_indexer"):
+            indexer.rebuild_index()
+
+        warnings = [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelname == "WARNING"
+        ]
+        assert any("memory/project/broken.md" in message for message in warnings)
+        assert not any("memory/project/ok.md" in message for message in warnings)
 
 
 class TestMaybeRebuild:
@@ -317,6 +493,113 @@ class TestRetrieve:
             results[0]["memory_description"]
             == "Practical rule for western blot buffer scaling when glycine is limited."
         )
+
+    def test_retrieve_carries_kind_scope_and_tags_in_result(self, indexer, tmp_path):
+        _write_memory_file(
+            tmp_path,
+            "memory/project/tagged.md",
+            (
+                "---\n"
+                "type: project_fact\n"
+                "name: Tagged project fact\n"
+                "description: Scoped example with tags.\n"
+                "tags: [rnaseq, de]\n"
+                "---\n"
+                "# Fact\nDifferential expression runs live under artifacts/de/.\n"
+            ),
+        )
+
+        results = indexer.retrieve("differential expression", top_k=2)
+
+        assert results
+        top = results[0]
+        assert top["memory_kind"] == "project"
+        assert top["memory_scope"] == "project"
+        assert top["memory_tags"] == ["rnaseq", "de"]
+
+    def _seed_kind_scope_corpus(self, tmp_path):
+        _write_memory_file(tmp_path, "memory/MEMORY.md", "# Index\n")
+        _write_memory_file(
+            tmp_path,
+            "memory/project/project-fact.md",
+            (
+                "---\n"
+                "type: project_fact\n"
+                "name: Project fact\n"
+                "description: BRCA1 outputs live under artifacts/evidence.\n"
+                "tags: [brca1, evidence]\n"
+                "---\n"
+                "BRCA1 differential expression follow-up lives in artifacts/evidence/.\n"
+            ),
+        )
+        _write_memory_file(
+            tmp_path,
+            "memory/user/user-preference.md",
+            (
+                "---\n"
+                "type: user_preference\n"
+                "name: Johnny preferences\n"
+                "description: Prefers concise plans for BRCA1 work.\n"
+                "tags: [preferences]\n"
+                "---\n"
+                "Prefer practical BRCA1 plans over abstract summaries.\n"
+            ),
+        )
+        _write_memory_file(
+            tmp_path,
+            "memory/agent/agent-policy.md",
+            (
+                "---\n"
+                "type: workflow_heuristic\n"
+                "name: Agent BRCA1 policy\n"
+                "description: Agent-wide guidance for BRCA1 follow-up notes.\n"
+                "---\n"
+                "Agent BRCA1 heuristic: always verify artifacts before quoting.\n"
+            ),
+        )
+
+    def test_retrieve_filters_by_single_kind(self, indexer, tmp_path):
+        self._seed_kind_scope_corpus(tmp_path)
+
+        results = indexer.retrieve("BRCA1", top_k=5, kind="project")
+
+        assert results
+        assert all(result["memory_kind"] == "project" for result in results)
+        assert all("memory/project/" in result["source"] for result in results)
+
+    def test_retrieve_filters_by_multiple_kinds(self, indexer, tmp_path):
+        self._seed_kind_scope_corpus(tmp_path)
+
+        results = indexer.retrieve("BRCA1", top_k=5, kind=["project", "user"])
+        sources = {result["source"] for result in results}
+
+        assert any("memory/project/" in source for source in sources)
+        assert any("memory/user/" in source for source in sources)
+        assert not any("memory/agent/" in source for source in sources)
+
+    def test_retrieve_filters_by_scope_global_only_returns_agent_kind(self, indexer, tmp_path):
+        self._seed_kind_scope_corpus(tmp_path)
+
+        results = indexer.retrieve("BRCA1", top_k=5, scope="global")
+
+        assert results
+        assert all(result["memory_scope"] == "global" for result in results)
+        assert all(result["memory_kind"] == "agent" for result in results)
+
+    def test_retrieve_filters_by_tag_intersection(self, indexer, tmp_path):
+        self._seed_kind_scope_corpus(tmp_path)
+
+        results = indexer.retrieve("BRCA1", top_k=5, tags="brca1")
+
+        assert results
+        assert all("brca1" in (result.get("memory_tags") or []) for result in results)
+
+    def test_retrieve_returns_empty_when_filter_excludes_all(self, indexer, tmp_path):
+        self._seed_kind_scope_corpus(tmp_path)
+
+        results = indexer.retrieve("BRCA1", top_k=5, scope="session")
+
+        assert results == []
 
     def test_retrieve_respects_top_k_when_lexical_fallback_matches_many_sections(self, indexer, tmp_path):
         _write_memory_file(tmp_path, "memory/MEMORY.md", "# Index\n")


### PR DESCRIPTION
## Summary

Extends the typed memory system with filtering capabilities and additional metadata fields. The `retrieve()` method now supports filtering by `kind` (project/user/agent), `scope` (session/project/user/global), and `tags`. Memory documents now carry these fields through indexing and retrieval, with sensible defaults for legacy files.

## Key Changes

- **New metadata fields**: `TypedMemoryMetadata` now includes `kind`, `scope`, `tags`, `pinned`, and `updated_at` fields
- **Filtering support**: `retrieve()` accepts optional `kind`, `scope`, and `tags` parameters to filter results
  - `kind` and `scope` support single string or iterable of strings
  - `tags` uses set intersection matching (a section matches if any of its tags intersect the filter set)
- **Path-based inference**: `infer_kind_from_source()` automatically determines kind from directory structure (memory/project/ → 'project', etc.)
- **Default scope mapping**: `default_scope_for_kind()` provides sensible defaults (project→project, user→user, agent→global)
- **Legacy file support**: Files without frontmatter are assigned kind/scope based on their directory, ensuring consistent filtering behavior between typed and legacy documents
- **Validation**: New schema validation for `kind`, `scope`, `tags`, `pinned`, and `updated_at` fields in `validate_memory_write()`
- **Startup logging**: `_log_malformed_documents()` logs malformed typed memory files at rebuild time without blocking startup
- **Filter normalization**: `_normalize_filter_values()` coerces filter inputs to lowercase sets for case-insensitive matching

## Implementation Details

- Filter matching is applied in both lexical (BM25) and vector retrieval paths via `_section_matches_filters()`
- The `remember_result()` closure in `retrieve()` applies filters before deduplication, ensuring consistent results
- Tags are normalized to lowercase deduplicated tuples during parsing
- Scope defaults are applied during document parsing, not at retrieval time, for consistency
- All new fields are carried through the indexing pipeline and included in vector metadata
- Comprehensive test coverage added for schema validation, filtering, and legacy file behavior

https://claude.ai/code/session_01QVRmmT14VsP1dxR9HYbjds