### PR TITLE
auto: #49 Runtime config provenance endpoint (/api/config/effective)

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -1,9 +1,11 @@
 """Operator-facing config inspection endpoints.
 
 GET /api/config/effective — return the active hardening posture, every
-derived flag that the posture expands into, and per-layer provenance from
-`runtime_config_types.LoadedRuntimeConfig`. Requires inspection access so
-remote operators cannot probe bearer-token env-var names anonymously.
+derived flag that the posture expands into, per-layer provenance from
+`runtime_config_types.LoadedRuntimeConfig`, and per-field provenance
+(``{field_path: {value, source_layer, path}}``) derived from the same
+merge. Requires admin access so remote operators cannot probe
+bearer-token env-var names or other sensitive settings anonymously.
 """
 
 from __future__ import annotations
@@ -11,7 +13,7 @@ from __future__ import annotations
 from dataclasses import asdict
 from typing import Any
 
-from access_control import require_inspection_access
+from access_control import require_admin_access
 from fastapi import APIRouter, Request
 
 import config as cfg
@@ -25,9 +27,22 @@ def _serialize_layer(layer: Any) -> dict[str, Any]:
     return payload
 
 
+def _serialize_field_provenance(
+    provenance: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    return {
+        field_path: {
+            "value": entry.value,
+            "source_layer": entry.source_layer,
+            "path": entry.path,
+        }
+        for field_path, entry in sorted(provenance.items())
+    }
+
+
 @router.get("/config/effective")
 def get_effective_config(request: Request = None):
-    require_inspection_access(request)
+    require_admin_access(request)
     loaded = cfg.get_loaded_runtime_config()
     policy = cfg.get_production_hardening_policy()
     return {
@@ -40,4 +55,5 @@ def get_effective_config(request: Request = None):
             "api": policy.api.model_dump(),
         },
         "config_layers": [_serialize_layer(layer) for layer in loaded.layers],
+        "field_provenance": _serialize_field_provenance(loaded.field_provenance),
     }

--- a/backend/docs/production-hardening.md
+++ b/backend/docs/production-hardening.md
@@ -66,11 +66,13 @@ baseline.
 ### Effective-posture inspection
 
 `GET /api/config/effective` returns the active posture, every derived
-flag, and per-layer config provenance drawn from
+flag, per-layer config provenance drawn from
 `runtime_config_types.LoadedRuntimeConfig` (defaults → user → project →
-local). The route is gated behind `require_inspection_access` so remote
-operators cannot probe bearer-token environment-variable names
-anonymously.
+local), and a `field_provenance` map that records which layer last set
+each effective leaf (`{field_path: {value, source_layer, path}}`). The
+route is gated behind `require_admin_access` so remote operators cannot
+probe bearer-token environment-variable names or other sensitive
+settings anonymously.
 
 ## Least-privilege expectations
 

--- a/backend/runtime_config.py
+++ b/backend/runtime_config.py
@@ -6,7 +6,12 @@ import os
 from pathlib import Path
 from typing import Any
 
-from runtime_config_types import LoadedRuntimeConfig, RuntimeConfigLayer
+from runtime_config_types import (
+    LoadedRuntimeConfig,
+    RuntimeConfigFieldProvenance,
+    RuntimeConfigLayer,
+    RuntimeConfigLayerName,
+)
 
 USER_CONFIG_ENV_VAR = "BIOAPEX_USER_CONFIG"
 PROJECT_CONFIG_ENV_VAR = "BIOAPEX_PROJECT_CONFIG"
@@ -21,6 +26,66 @@ def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]
         else:
             merged[key] = copy.deepcopy(value)
     return merged
+
+
+def _iter_leaves(prefix: str, value: Any):
+    """Yield (dotted_path, leaf_value) for every leaf reachable from value."""
+    if isinstance(value, dict):
+        for key, child in value.items():
+            sub = f"{prefix}.{key}" if prefix else key
+            yield from _iter_leaves(sub, child)
+    else:
+        yield prefix, value
+
+
+def _apply_overlay_with_provenance(
+    merged: dict[str, Any],
+    overlay: dict[str, Any],
+    provenance: dict[str, RuntimeConfigFieldProvenance],
+    *,
+    layer_name: RuntimeConfigLayerName,
+    layer_path: str | None,
+    prefix: str = "",
+) -> None:
+    """Merge ``overlay`` into ``merged`` while recording leaf-level provenance.
+
+    A "leaf" is any non-dict value. When a later layer replaces a previous leaf
+    or a whole subtree, its provenance entries supersede the earlier layer's.
+    """
+
+    for key, overlay_value in overlay.items():
+        sub_prefix = f"{prefix}.{key}" if prefix else key
+        current = merged.get(key)
+
+        if isinstance(overlay_value, dict) and isinstance(current, dict):
+            _apply_overlay_with_provenance(
+                current,
+                overlay_value,
+                provenance,
+                layer_name=layer_name,
+                layer_path=layer_path,
+                prefix=sub_prefix,
+            )
+            continue
+
+        # The overlay replaces the current value wholesale. Drop any previous
+        # provenance entries rooted at this path so stale child leaves do not
+        # survive a type change (e.g. dict → scalar) or a scalar → dict swap.
+        provenance.pop(sub_prefix, None)
+        stale_children = [
+            existing for existing in provenance if existing.startswith(sub_prefix + ".")
+        ]
+        for existing in stale_children:
+            provenance.pop(existing, None)
+
+        merged[key] = copy.deepcopy(overlay_value)
+
+        for leaf_path, leaf_value in _iter_leaves(sub_prefix, overlay_value):
+            provenance[leaf_path] = RuntimeConfigFieldProvenance(
+                value=copy.deepcopy(leaf_value),
+                source_layer=layer_name,
+                path=layer_path,
+            )
 
 
 def _load_json_object(path: Path) -> dict[str, Any]:
@@ -61,7 +126,17 @@ def load_runtime_config(
     default_config: dict[str, Any],
     project_config_path: Path,
 ) -> LoadedRuntimeConfig:
-    merged = copy.deepcopy(default_config)
+    merged: dict[str, Any] = {}
+    provenance: dict[str, RuntimeConfigFieldProvenance] = {}
+
+    _apply_overlay_with_provenance(
+        merged,
+        default_config,
+        provenance,
+        layer_name="defaults",
+        layer_path=None,
+    )
+
     paths = resolve_runtime_config_paths(project_config_path)
     layers: list[RuntimeConfigLayer] = [
         RuntimeConfigLayer(
@@ -77,7 +152,13 @@ def load_runtime_config(
         path = paths[layer_name]
         payload = _load_json_object(path)
         if payload:
-            merged = _deep_merge(merged, payload)
+            _apply_overlay_with_provenance(
+                merged,
+                payload,
+                provenance,
+                layer_name=layer_name,  # type: ignore[arg-type]
+                layer_path=str(path),
+            )
         layers.append(
             RuntimeConfigLayer(
                 name=layer_name,  # type: ignore[arg-type]
@@ -88,4 +169,8 @@ def load_runtime_config(
             )
         )
 
-    return LoadedRuntimeConfig(data=merged, layers=tuple(layers))
+    return LoadedRuntimeConfig(
+        data=merged,
+        layers=tuple(layers),
+        field_provenance=provenance,
+    )

--- a/backend/runtime_config_types.py
+++ b/backend/runtime_config_types.py
@@ -16,6 +16,16 @@ class RuntimeConfigLayer:
 
 
 @dataclass(frozen=True)
+class RuntimeConfigFieldProvenance:
+    """Provenance for one effective leaf field in the merged runtime config."""
+
+    value: Any
+    source_layer: RuntimeConfigLayerName
+    path: str | None
+
+
+@dataclass(frozen=True)
 class LoadedRuntimeConfig:
     data: dict[str, Any]
     layers: tuple[RuntimeConfigLayer, ...]
+    field_provenance: dict[str, RuntimeConfigFieldProvenance]

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -246,3 +246,83 @@ class TestConfig:
 
             assert config.get_agent_runtime_limit("executor_recursion_limit", 1000) == 1000
             assert config.get_agent_runtime_limit("helper_agent_recursion_limit", 1000) == 1000
+
+    def test_effective_config_endpoint_reports_per_field_provenance(self, tmp_path):
+        user_cfg = tmp_path / "user-config.json"
+        project_cfg = tmp_path / "config.json"
+        local_cfg = tmp_path / "config.local.json"
+
+        user_cfg.write_text(
+            json.dumps(
+                {
+                    "rag_mode": True,
+                    "prompt_context": {"include_git_context": True},
+                    "tool_policy": {"warn_on_missing_artifact_refs": False},
+                }
+            ),
+            encoding="utf-8",
+        )
+        project_cfg.write_text(
+            json.dumps(
+                {
+                    "rag_mode": False,
+                    "tool_policy": {"enabled": False},
+                }
+            ),
+            encoding="utf-8",
+        )
+        local_cfg.write_text(
+            json.dumps(
+                {
+                    "tool_policy": {"enabled": True},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch("config._CONFIG_FILE", project_cfg), patch.dict(
+            os.environ,
+            {
+                "BIOAPEX_USER_CONFIG": str(user_cfg),
+                "BIOAPEX_LOCAL_CONFIG": str(local_cfg),
+            },
+            clear=False,
+        ):
+            from api.config import get_effective_config
+
+            response = get_effective_config(request=None)
+
+        assert "field_provenance" in response
+        provenance = response["field_provenance"]
+
+        # Local overrides project override → tool_policy.enabled came from local.
+        enabled_entry = provenance["tool_policy.enabled"]
+        assert enabled_entry["value"] is True
+        assert enabled_entry["source_layer"] == "local"
+        assert enabled_entry["path"] == str(local_cfg)
+
+        # Project overrides user → rag_mode came from project.
+        rag_entry = provenance["rag_mode"]
+        assert rag_entry["value"] is False
+        assert rag_entry["source_layer"] == "project"
+        assert rag_entry["path"] == str(project_cfg)
+
+        # Only user set this flag → source is user.
+        git_entry = provenance["prompt_context.include_git_context"]
+        assert git_entry["value"] is True
+        assert git_entry["source_layer"] == "user"
+        assert git_entry["path"] == str(user_cfg)
+
+        # Only user set this flag → source is user.
+        warn_entry = provenance["tool_policy.warn_on_missing_artifact_refs"]
+        assert warn_entry["value"] is False
+        assert warn_entry["source_layer"] == "user"
+
+        # Untouched defaults should still report provenance from defaults.
+        memory_stale = provenance["prompt_context.memory_stale_days"]
+        assert memory_stale["source_layer"] == "defaults"
+        assert memory_stale["path"] is None
+
+        # Backwards-compatible layer summary remains alongside field_provenance.
+        layer_names = [layer["name"] for layer in response["config_layers"]]
+        assert layer_names == ["defaults", "user", "project", "local"]


### PR DESCRIPTION
Closes #49

Opened by the personal automation loop. Draft until human-reviewed.