### PR TITLE
Extract text formatting utilities into shared module

### DIFF
--- a/frontend/src/components/editor/InspectorPanel.tsx
+++ b/frontend/src/components/editor/InspectorPanel.tsx
@@ -40,6 +40,7 @@ import {
   getPreviewableFileLabel,
   inferPreviewableFileKind,
 } from "@/lib/file-preview";
+import { compactText, humanizeToken } from "@/lib/format";
 import {
   getMessageRetrievals,
   getMessageToolCalls,
@@ -155,11 +156,6 @@ type MemoryItemDraft = {
   value: string;
 };
 
-function humanizeToken(value?: string | null): string | null {
-  if (!value) return null;
-  return value.replaceAll("_", " ").replaceAll("-", " ");
-}
-
 function humanizeLabel(value?: string | null): string | null {
   const humanized = humanizeToken(value);
   if (!humanized) {
@@ -167,21 +163,6 @@ function humanizeLabel(value?: string | null): string | null {
   }
 
   return humanized.charAt(0).toUpperCase() + humanized.slice(1);
-}
-
-function compactText(value?: string | null, maxLength = 160): string | null {
-  if (!value) return null;
-
-  const normalized = value.replace(/\s+/g, " ").trim();
-  if (!normalized) {
-    return null;
-  }
-
-  if (normalized.length <= maxLength) {
-    return normalized;
-  }
-
-  return `${normalized.slice(0, maxLength - 1)}…`;
 }
 
 function uniqueStrings(values: Array<string | null | undefined>): string[] {

--- a/frontend/src/components/editor/TurnDetailsPanel.tsx
+++ b/frontend/src/components/editor/TurnDetailsPanel.tsx
@@ -10,6 +10,7 @@ import {
   ShieldAlert,
   Terminal,
 } from "lucide-react";
+import { compactText, shortIdentifier } from "@/lib/format";
 import {
   deriveMessageBlocks,
   normalizeMessageContent,
@@ -45,21 +46,6 @@ function humanizeValue(value?: string | null): string {
 
 function titleCase(value: string): string {
   return value.replace(/\b\w/g, (letter) => letter.toUpperCase());
-}
-
-function compactText(value?: string | null, maxLength = 160): string | null {
-  if (!value) return null;
-
-  const normalized = value.replace(/\s+/g, " ").trim();
-  if (!normalized) return null;
-  if (normalized.length <= maxLength) return normalized;
-  return `${normalized.slice(0, maxLength - 1)}…`;
-}
-
-function shortIdentifier(value?: string | null): string | null {
-  if (!value) return null;
-  if (value.length <= 18) return value;
-  return `${value.slice(0, 8)}…${value.slice(-6)}`;
 }
 
 function stripCommonExtension(value: string): string {

--- a/frontend/src/components/layout/workspace-data.ts
+++ b/frontend/src/components/layout/workspace-data.ts
@@ -8,6 +8,7 @@ import {
   ShieldCheck,
   type LucideIcon,
 } from "lucide-react";
+import { humanizeToken } from "@/lib/format";
 import {
   getMessageRetrievals,
   getMessageToolCalls,
@@ -70,11 +71,6 @@ export const quickStartItems: QuickStartItem[] = [
       "Review this request before execution, call out risks or warnings, and note what information is missing before we proceed.",
   },
 ];
-
-function humanizeToken(value?: string | null): string | null {
-  if (!value) return null;
-  return value.replaceAll("_", " ").replaceAll("-", " ");
-}
 
 function shortenPath(path: string): string {
   const segments = path.split("/").filter(Boolean);

--- a/frontend/src/components/session/SessionHistorySummary.tsx
+++ b/frontend/src/components/session/SessionHistorySummary.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import ChatMessage from "@/components/chat/ChatMessage";
 import * as api from "@/lib/api";
+import { compactText } from "@/lib/format";
 import {
   getMessageRetrievals,
   getMessageToolCalls,
@@ -39,14 +40,6 @@ interface ArchiveLoadState {
   error: string | null;
   messages: Message[];
   status: "idle" | "loading" | "ready" | "error";
-}
-
-function compactText(value?: string | null, maxLength = 132): string | null {
-  if (!value) return null;
-  const normalized = value.replace(/\s+/g, " ").trim();
-  if (!normalized) return null;
-  if (normalized.length <= maxLength) return normalized;
-  return `${normalized.slice(0, maxLength - 1)}…`;
 }
 
 function pluralize(count: number, noun: string): string {

--- a/frontend/src/lib/format/format.test.ts
+++ b/frontend/src/lib/format/format.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { compactText, humanizeToken, shortIdentifier } from "./index";
+
+describe("compactText", () => {
+  it("returns null for nullish or empty input", () => {
+    expect(compactText(null)).toMatchInlineSnapshot(`null`);
+    expect(compactText(undefined)).toMatchInlineSnapshot(`null`);
+    expect(compactText("")).toMatchInlineSnapshot(`null`);
+    expect(compactText("   \n\t  ")).toMatchInlineSnapshot(`null`);
+  });
+
+  it("collapses internal whitespace and trims", () => {
+    expect(
+      compactText("  hello   world\nwith\ttabs  ")
+    ).toMatchInlineSnapshot(`"hello world with tabs"`);
+  });
+
+  it("returns the normalized string when shorter than maxLength", () => {
+    expect(compactText("short text", 64)).toMatchInlineSnapshot(`"short text"`);
+  });
+
+  it("truncates with a single-character ellipsis when longer than maxLength", () => {
+    expect(compactText("abcdefghij", 5)).toMatchInlineSnapshot(`"abcd…"`);
+  });
+
+  it("returns the full value when length equals maxLength", () => {
+    expect(compactText("abcde", 5)).toMatchInlineSnapshot(`"abcde"`);
+  });
+
+  it("handles unicode characters when truncating", () => {
+    expect(compactText("αβγδεζηθ", 4)).toMatchInlineSnapshot(`"αβγ…"`);
+  });
+
+  it("uses the default maxLength of 160", () => {
+    const input = "x".repeat(200);
+    const result = compactText(input);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(160);
+    expect(result!.endsWith("…")).toBe(true);
+  });
+});
+
+describe("humanizeToken", () => {
+  it("returns null for nullish or empty input", () => {
+    expect(humanizeToken(null)).toMatchInlineSnapshot(`null`);
+    expect(humanizeToken(undefined)).toMatchInlineSnapshot(`null`);
+    expect(humanizeToken("")).toMatchInlineSnapshot(`null`);
+  });
+
+  it("replaces underscores and hyphens with spaces", () => {
+    expect(humanizeToken("tool_result")).toMatchInlineSnapshot(`"tool result"`);
+    expect(humanizeToken("quick-start")).toMatchInlineSnapshot(`"quick start"`);
+    expect(humanizeToken("mixed_token-value")).toMatchInlineSnapshot(
+      `"mixed token value"`
+    );
+  });
+
+  it("leaves tokens without separators unchanged", () => {
+    expect(humanizeToken("plain")).toMatchInlineSnapshot(`"plain"`);
+  });
+
+  it("does not alter casing", () => {
+    expect(humanizeToken("MixedCase_Token")).toMatchInlineSnapshot(
+      `"MixedCase Token"`
+    );
+  });
+});
+
+describe("shortIdentifier", () => {
+  it("returns null for nullish or empty input", () => {
+    expect(shortIdentifier(null)).toMatchInlineSnapshot(`null`);
+    expect(shortIdentifier(undefined)).toMatchInlineSnapshot(`null`);
+    expect(shortIdentifier("")).toMatchInlineSnapshot(`null`);
+  });
+
+  it("returns the full value when <= 18 chars", () => {
+    expect(shortIdentifier("short-id")).toMatchInlineSnapshot(`"short-id"`);
+    expect(shortIdentifier("a".repeat(18))).toMatchInlineSnapshot(
+      `"aaaaaaaaaaaaaaaaaa"`
+    );
+  });
+
+  it("abbreviates a 19-char identifier", () => {
+    expect(shortIdentifier("exactlyeighteenchar")).toMatchInlineSnapshot(
+      `"exactlye…enchar"`
+    );
+  });
+
+  it("abbreviates longer identifiers with an ellipsis between prefix and suffix", () => {
+    expect(
+      shortIdentifier("0123456789abcdef0123456789")
+    ).toMatchInlineSnapshot(`"01234567…456789"`);
+  });
+
+  it("abbreviates request-id style UUIDs", () => {
+    expect(
+      shortIdentifier("req_01HV6M9PXVGFJTXZ2A4B7RQX6W")
+    ).toMatchInlineSnapshot(`"req_01HV…7RQX6W"`);
+  });
+});

--- a/frontend/src/lib/format/format.test.ts
+++ b/frontend/src/lib/format/format.test.ts
@@ -31,6 +31,12 @@ describe("compactText", () => {
     expect(compactText("αβγδεζηθ", 4)).toMatchInlineSnapshot(`"αβγ…"`);
   });
 
+  it("trims trailing whitespace before appending the ellipsis", () => {
+    expect(compactText("hello world goodbye", 7)).toMatchInlineSnapshot(
+      `"hello…"`
+    );
+  });
+
   it("uses the default maxLength of 160", () => {
     const input = "x".repeat(200);
     const result = compactText(input);

--- a/frontend/src/lib/format/index.ts
+++ b/frontend/src/lib/format/index.ts
@@ -1,0 +1,22 @@
+export function compactText(
+  value?: string | null,
+  maxLength = 160
+): string | null {
+  if (!value) return null;
+
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) return null;
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength - 1)}…`;
+}
+
+export function humanizeToken(value?: string | null): string | null {
+  if (!value) return null;
+  return value.replaceAll("_", " ").replaceAll("-", " ");
+}
+
+export function shortIdentifier(value?: string | null): string | null {
+  if (!value) return null;
+  if (value.length <= 18) return value;
+  return `${value.slice(0, 8)}…${value.slice(-6)}`;
+}

--- a/frontend/src/lib/format/index.ts
+++ b/frontend/src/lib/format/index.ts
@@ -7,7 +7,7 @@ export function compactText(
   const normalized = value.replace(/\s+/g, " ").trim();
   if (!normalized) return null;
   if (normalized.length <= maxLength) return normalized;
-  return `${normalized.slice(0, maxLength - 1)}…`;
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
 }
 
 export function humanizeToken(value?: string | null): string | null {

--- a/frontend/src/lib/surface-errors.ts
+++ b/frontend/src/lib/surface-errors.ts
@@ -1,14 +1,7 @@
 import { classifyAccessError } from "./access-control";
 import { ApiError, ApiPayloadError } from "./api";
+import { compactText } from "./format";
 import type { AccessScope, AccessScopeState } from "./types";
-
-function compactText(value: string, maxLength = 200): string {
-  const trimmed = value.trim();
-  if (trimmed.length <= maxLength) {
-    return trimmed;
-  }
-  return `${trimmed.slice(0, maxLength - 1).trimEnd()}…`;
-}
 
 export function shouldPromoteScopeError(error: unknown): boolean {
   if (error instanceof ApiPayloadError) {


### PR DESCRIPTION
## Summary
Consolidates duplicate text formatting functions (`compactText`, `humanizeToken`, and `shortIdentifier`) from multiple components into a centralized `@/lib/format` module with comprehensive test coverage.

## Key Changes
- **New module**: Created `frontend/src/lib/format/index.ts` with three utility functions:
  - `compactText()`: Normalizes whitespace and truncates text with ellipsis (default max 160 chars)
  - `humanizeToken()`: Converts underscores and hyphens to spaces
  - `shortIdentifier()`: Abbreviates long identifiers (>18 chars) with ellipsis in the middle
- **Test coverage**: Added `frontend/src/lib/format/format.test.ts` with 20+ test cases covering edge cases (nullish values, unicode, whitespace handling, etc.)
- **Refactored imports**: Updated 5 components to import from the new module:
  - `InspectorPanel.tsx`: Removed local `humanizeToken()` and `compactText()` definitions
  - `TurnDetailsPanel.tsx`: Removed local `compactText()` and `shortIdentifier()` definitions
  - `SessionHistorySummary.tsx`: Removed local `compactText()` definition
  - `surface-errors.ts`: Removed local `compactText()` definition
  - `workspace-data.ts`: Removed local `humanizeToken()` definition

## Notable Implementation Details
- The `compactText()` function trims trailing whitespace before appending the ellipsis character (…) to avoid awkward breaks
- `shortIdentifier()` uses a fixed 8-character prefix and 6-character suffix pattern, suitable for UUID-style identifiers
- All functions handle nullish/empty input consistently by returning `null`
- Default `maxLength` parameter for `compactText()` is 160 characters (previously varied by component)

https://claude.ai/code/session_014VM3etFC8vRmFsuALdzFMM