### PR TITLE
docs(context): mark compliance-and-approval UI spec (#62) as superseded

### DIFF
--- a/context/features/62-compliance-and-approval-ui-spec.md
+++ b/context/features/62-compliance-and-approval-ui-spec.md
@@ -1,5 +1,19 @@
 # Compliance And Approval UI Spec
 
+> **Status: Superseded (2026-04-03).** This spec is retained for historical
+> reference only. The compliance-preflight runtime and the compliance-first
+> UI surface it assumed were removed by the two 2026-04-03 slices:
+> `.omx/plans/remove-compliance-preflight-active-runtime-slice-2026-04-03.md`
+> and `.omx/plans/remove-stale-routes-and-compliance-ui-slice-2026-04-03.md`.
+> The active SSE contract no longer emits compliance dispositions; tool
+> gating is handled by `tool_awaiting_approval` and
+> `frontend/src/components/chat/ApprovalGate.tsx`, not by severity-based
+> compliance states. `ComplianceDisposition` in `frontend/src/lib/types.ts`
+> and `ComplianceReportArtifact` in `frontend/src/test/fixtures.ts` survive
+> only for archived-session deserialization. Do not build against this
+> document; open a fresh spec if severity-based disclosure is revived. See
+> Azealoo/miniAgent#73 for the triage that closed this out.
+
 ## Overview
 
 Build the compliance surface required for a production-grade BioAPEX frontend. The backend now supports dispositions such as `allow_with_warning`, `require_approval`, and `block`, plus structured compliance report artifacts. This phase should make those states visible, understandable, and hard to ignore.


### PR DESCRIPTION
## Summary

- Marks `context/features/62-compliance-and-approval-ui-spec.md` as superseded at the top, with a pointer to the two 2026-04-03 removal slices that stripped the compliance-preflight runtime and compliance-first UI surface it assumed.
- Resolves the stale-spec half of the triage on #73 (recommending the issue itself be closed as obsoleted).

## Why

Per `CLAUDE.md`:

> Prefer the behavior the code actually exhibits over any older narrative in this file or in `README.md` — if they disagree, the code wins and the docs should be corrected in the same PR.

Spec #62 still described a severity-based compliance UI (`allow` / `allow_with_warning` / `require_approval` / `block`) and claimed the backend emitted those dispositions. Neither is true after the 2026-04-03 slices:

- `.omx/plans/remove-compliance-preflight-active-runtime-slice-2026-04-03.md` removed `compliance_preflight_required` and the preflight policy surface from `backend/tools/policy.py`, `policy_types.py`, `registry.py`.
- `.omx/plans/remove-stale-routes-and-compliance-ui-slice-2026-04-03.md` removed compliance cards from the inspector and compliance-specific copy from turn activity, turn details, session history summaries, and navbar readiness.

`frontend/src/lib/chat-stream-reducer.ts` has no compliance branch; `backend/runtime/hooks.py` statuses (`allow/deny/ask/modify`) are tool-hook decisions, not compliance dispositions. `ComplianceDisposition` and `ComplianceReportArtifact` survive only for archived-session deserialization.

Leaving the spec un-marked made issue #73 ("Severity-based compliance disclosure rollout") look actionable when it is actually obsolete. This PR fixes that.

## Test plan

- [ ] Confirm the superseded banner renders at the top of `context/features/62-compliance-and-approval-ui-spec.md` when viewed on GitHub.
- [ ] No code or runtime changes — backend pytest and frontend typecheck/vitest/lint unaffected; no CI gate expected to change.

https://claude.ai/code/session_01WqJ4q3E8FYXa6WDQcfMia4