### PR TITLE
auto: #84 Two-phase skill loading (frontmatter-first, body-on-demand)

### DIFF
--- a/backend/tests/test_skills_scanner.py
+++ b/backend/tests/test_skills_scanner.py
@@ -12,9 +12,12 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from tools.skills_scanner import (
+    SkillRegistry,
     _parse_frontmatter,
     collect_skill_entries,
     describe_skill_registry,
+    get_body,
+    get_frontmatter,
     scan_skills,
     skill_required_env_satisfied,
 )
@@ -675,3 +678,121 @@ class TestExtendedSkillContract:
         )
         entry = collect_skill_entries(tmp_path, respect_enabled=False)[0]
         assert entry["required_env"] == ["FOO_TOKEN", "BAR_TOKEN"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# SkillRegistry — two-phase frontmatter / body access
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+_BODY_MARKER = "UNIQUE_BODY_MARKER_8f3a1c"
+
+
+def _write_skill_with_body(
+    base: Path, name: str, *, body: str, description: str = "Two-phase skill"
+) -> Path:
+    skill_dir = base / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_path = skill_dir / "SKILL.md"
+    skill_path.write_text(
+        (
+            f"---\nname: {name}\ndescription: {description}\ncategory: bio/literature\n"
+            "requires_tools: [read_file]\nrequires_network: false\nuser_invocable: true\n"
+            "species: any\nmodality: literature\nstage: analysis\n"
+            "stability: experimental\nsafety_level: low\n"
+            f"---\n{body}"
+        ),
+        encoding="utf-8",
+    )
+    return skill_path
+
+
+class TestSkillRegistryTwoPhase:
+    def test_snapshot_contains_frontmatter_only_no_body_text(self, tmp_path):
+        _write_skill_with_body(
+            tmp_path,
+            "two_phase_skill",
+            body=f"# Steps\n{_BODY_MARKER}\nLots of private body instructions.\n",
+        )
+
+        scan_skills(tmp_path)
+        content = (tmp_path / "SKILLS_SNAPSHOT.md").read_text()
+
+        assert "two_phase_skill" in content  # frontmatter name is present
+        assert _BODY_MARKER not in content
+        assert "private body instructions" not in content
+        assert "# Steps" not in content
+
+    def test_get_body_loads_post_frontmatter_content_on_demand(self, tmp_path):
+        body_text = f"# Steps\n{_BODY_MARKER}\n1. Do the thing.\n"
+        skill_path = _write_skill_with_body(
+            tmp_path, "on_demand_skill", body=body_text
+        )
+
+        registry = SkillRegistry(tmp_path, respect_enabled=False)
+
+        frontmatter = registry.get_frontmatter("on_demand_skill")
+        assert frontmatter is not None
+        assert frontmatter["name"] == "on_demand_skill"
+        assert _BODY_MARKER not in repr(frontmatter)
+
+        loaded_body = registry.get_body("on_demand_skill")
+        assert loaded_body is not None
+        assert loaded_body.startswith("# Steps")
+        assert _BODY_MARKER in loaded_body
+        # Closing frontmatter delimiter must not leak into the body.
+        assert not loaded_body.lstrip().startswith("---")
+        assert "category: bio/literature" not in loaded_body
+
+        # Body must match what's on disk after the frontmatter block.
+        raw = skill_path.read_text(encoding="utf-8")
+        assert loaded_body == raw.split("---", 2)[2].lstrip("\n")
+
+    def test_get_body_returns_none_for_unknown_skill(self, tmp_path):
+        _write_skill_with_body(tmp_path, "known_skill", body="# hi\n")
+        registry = SkillRegistry(tmp_path, respect_enabled=False)
+        assert registry.get_body("does_not_exist") is None
+        assert registry.get_frontmatter("does_not_exist") is None
+
+    def test_get_body_is_lazy_then_cached(self, tmp_path):
+        skill_path = _write_skill_with_body(
+            tmp_path, "lazy_skill", body=f"original\n{_BODY_MARKER}\n"
+        )
+        registry = SkillRegistry(tmp_path, respect_enabled=False)
+
+        # Constructing the registry and inspecting frontmatter must not
+        # pre-load the body — the first get_body() call picks up the
+        # current on-disk body.
+        assert registry.get_frontmatter("lazy_skill") is not None
+
+        header = skill_path.read_text(encoding="utf-8").split("---", 2)
+        skill_path.write_text(
+            f"---{header[1]}---\nupdated\n{_BODY_MARKER}\n", encoding="utf-8"
+        )
+
+        first_body = registry.get_body("lazy_skill")
+        assert first_body is not None
+        assert first_body.startswith("updated")
+
+        # After the first read the body is cached; later on-disk edits are
+        # intentionally not re-read.
+        skill_path.write_text(
+            skill_path.read_text(encoding="utf-8").replace("updated", "changed_again"),
+            encoding="utf-8",
+        )
+        assert registry.get_body("lazy_skill") == first_body
+
+    def test_module_level_helpers_expose_same_two_phase_api(self, tmp_path):
+        _write_skill_with_body(
+            tmp_path,
+            "helper_skill",
+            body=f"body-line\n{_BODY_MARKER}\n",
+        )
+        frontmatter = get_frontmatter(tmp_path, "helper_skill", respect_enabled=False)
+        body = get_body(tmp_path, "helper_skill", respect_enabled=False)
+
+        assert frontmatter is not None
+        assert frontmatter["name"] == "helper_skill"
+        assert body is not None
+        assert _BODY_MARKER in body
+        assert "helper_skill" not in body  # name lived in frontmatter only

--- a/backend/tools/skills_scanner.py
+++ b/backend/tools/skills_scanner.py
@@ -455,6 +455,110 @@ def scan_skills(base_dir: Path) -> None:
     snapshot_path.write_text(render_skills_snapshot(skill_entries), encoding="utf-8")
 
 
+def _extract_skill_body(content: str) -> str:
+    """Return the post-frontmatter body of a SKILL.md document.
+
+    If no frontmatter delimiters are present, the entire content is treated as
+    body. Leading whitespace after the closing ``---`` is stripped so callers
+    get the usable body directly.
+    """
+    if not content.startswith("---"):
+        return content
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return content
+    return parts[2].lstrip("\n")
+
+
+class SkillRegistry:
+    """Two-phase accessor for SKILL.md metadata and bodies.
+
+    Frontmatter for every discovered skill is parsed eagerly on first access
+    (cached keyed by skill name), while the post-frontmatter body is read from
+    disk only when ``get_body(name)`` is called. This keeps the default prompt
+    frontmatter-only and defers body loads to the moment the model or a user
+    slash command actually needs the full instructions.
+    """
+
+    def __init__(self, base_dir: Path, *, respect_enabled: bool = True) -> None:
+        self.base_dir = base_dir
+        self._respect_enabled = respect_enabled
+        self._frontmatter: dict[str, dict[str, Any]] | None = None
+        self._paths: dict[str, Path] = {}
+        self._body_cache: dict[str, str] = {}
+
+    def _ensure_loaded(self) -> None:
+        if self._frontmatter is not None:
+            return
+        frontmatter: dict[str, dict[str, Any]] = {}
+        paths: dict[str, Path] = {}
+        for entry in collect_skill_entries(
+            self.base_dir, respect_enabled=self._respect_enabled
+        ):
+            name = entry["name"]
+            if name in frontmatter:
+                continue
+            frontmatter[name] = entry
+            paths[name] = _resolve_skill_path(self.base_dir, entry)
+        self._frontmatter = frontmatter
+        self._paths = paths
+
+    def names(self) -> list[str]:
+        self._ensure_loaded()
+        assert self._frontmatter is not None
+        return list(self._frontmatter.keys())
+
+    def get_frontmatter(self, name: str) -> dict[str, Any] | None:
+        """Return cached frontmatter metadata for ``name`` or None if unknown."""
+        self._ensure_loaded()
+        assert self._frontmatter is not None
+        return self._frontmatter.get(name)
+
+    def get_body(self, name: str) -> str | None:
+        """Return the post-frontmatter body of ``name``'s SKILL.md on demand.
+
+        The body is read from disk the first time it is requested and cached
+        for subsequent calls; frontmatter-only consumers never pay this cost.
+        Returns None when the skill is unknown or its source file is missing.
+        """
+        if name in self._body_cache:
+            return self._body_cache[name]
+        self._ensure_loaded()
+        path = self._paths.get(name)
+        if path is None or not path.exists():
+            return None
+        content = path.read_text(encoding="utf-8")
+        body = _extract_skill_body(content)
+        self._body_cache[name] = body
+        return body
+
+
+def _resolve_skill_path(base_dir: Path, entry: dict[str, Any]) -> Path:
+    location = entry.get("location", "")
+    if isinstance(location, str) and location.startswith("./"):
+        return base_dir / location[2:]
+    if isinstance(location, str) and location:
+        candidate = Path(location)
+        if candidate.is_absolute():
+            return candidate
+        return base_dir / candidate
+    return base_dir / "skills" / entry.get("name", "") / "SKILL.md"
+
+
+def get_frontmatter(
+    base_dir: Path, name: str, *, respect_enabled: bool = True
+) -> dict[str, Any] | None:
+    """Module-level helper returning cached frontmatter for ``name``."""
+    return SkillRegistry(base_dir, respect_enabled=respect_enabled).get_frontmatter(name)
+
+
+def get_body(
+    base_dir: Path, name: str, *, respect_enabled: bool = True
+) -> str | None:
+    """Module-level helper returning the on-demand body for ``name``."""
+    return SkillRegistry(base_dir, respect_enabled=respect_enabled).get_body(name)
+
+
 def skill_required_env_satisfied(
     entry: dict[str, Any],
     *,


### PR DESCRIPTION
Closes #84

Opened by the personal automation loop. Draft until human-reviewed.