### PR TITLE
auto: #96 Bound the SSE buffer — memory DoS risk

### DIFF
--- a/frontend/src/lib/api.stream-chat.test.ts
+++ b/frontend/src/lib/api.stream-chat.test.ts
@@ -388,6 +388,64 @@ describe("streamChat", () => {
     expect(surfacedRequestIds).toEqual(["request-truncated-1"]);
   });
 
+  it("dispatches stream_overflow and cancels the reader when the buffered remainder exceeds the cap", async () => {
+    const cap = 256;
+    // A `data:` line with no terminator longer than the cap, followed by a
+    // legitimate `done` event. The cancel() should fire before `done` is
+    // surfaced to the dispatcher, so onDone must not be called.
+    const oversizedLine = "data: " + "x".repeat(cap + 64);
+    const trailingDone = `data: ${JSON.stringify({
+      type: "done",
+      content: "should not be reached",
+      request_id: "request-overflow-trailing",
+      event_index: 99,
+    })}\n\n`;
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      sseResponse([oversizedLine, trailingDone], { chunkSize: 64 })
+    );
+
+    const eventTypes: string[] = [];
+    const overflows: Array<{
+      bufferedBytes: number;
+      maxBufferBytes: number;
+    }> = [];
+    let sawDone = false;
+    const surfacedErrors: string[] = [];
+
+    await streamChat(
+      "Send a giant payload.",
+      "session-overflow",
+      {
+        onEvent: (event) => {
+          eventTypes.push(event.type);
+        },
+        onStreamOverflow: (event) => {
+          overflows.push({
+            bufferedBytes: event.bufferedBytes,
+            maxBufferBytes: event.maxBufferBytes,
+          });
+        },
+        onDone: () => {
+          sawDone = true;
+        },
+        onError: (error) => {
+          surfacedErrors.push(error);
+        },
+      },
+      { maxBufferBytes: cap }
+    );
+
+    expect(overflows).toHaveLength(1);
+    expect(overflows[0].maxBufferBytes).toBe(cap);
+    expect(overflows[0].bufferedBytes).toBeGreaterThan(cap);
+    expect(eventTypes).toContain("stream_overflow");
+    // Overflow is terminal — no synthetic "stream closed before completion"
+    // error and no surfaced trailing `done` event.
+    expect(sawDone).toBe(false);
+    expect(surfacedErrors).toEqual([]);
+  });
+
   it("cancels the in-flight fetch when the AbortController is aborted", async () => {
     let receivedSignal: AbortSignal | undefined;
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -381,6 +381,12 @@ export interface StreamChatOptions {
    * per-turn request_id; this override is not forwarded in the request body.
    */
   requestId?: string;
+  /**
+   * Cap on the SSE parser's unterminated buffered remainder. Defaults to the
+   * parser's own default (4 MB). When exceeded, a synthetic
+   * `stream_overflow` event is dispatched and the reader is cancelled.
+   */
+  maxBufferBytes?: number;
 }
 
 export async function streamChat(
@@ -413,27 +419,50 @@ export async function streamChat(
 
   const reader = response.body.getReader();
   const decoder = new TextDecoder("utf-8");
+  const parseOptions = { maxBufferBytes: options.maxBufferBytes };
   let buffer = "";
+  let aborted = false;
 
   try {
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
-      const parsed = parseChatStreamChunk(buffer, decoder.decode(value, { stream: true }));
+      const parsed = parseChatStreamChunk(
+        buffer,
+        decoder.decode(value, { stream: true }),
+        parseOptions
+      );
       buffer = parsed.bufferedRemainder;
       for (const event of parsed.events) dispatcher.dispatch(event);
+      if (parsed.overflow) {
+        dispatcher.dispatch({
+          type: "stream_overflow",
+          bufferedBytes: parsed.overflow.bufferedBytes,
+          maxBufferBytes: parsed.overflow.maxBufferBytes,
+          request_id: dispatcher.lastRequestId() ?? options.requestId,
+        });
+        buffer = "";
+        aborted = true;
+        await reader.cancel().catch(() => undefined);
+        break;
+      }
     }
 
-    const finalParsed = parseChatStreamChunk(buffer, decoder.decode(), { flush: true });
-    buffer = finalParsed.bufferedRemainder;
-    for (const event of finalParsed.events) dispatcher.dispatch(event);
-
-    if (!dispatcher.sawTerminalEvent()) {
-      dispatcher.dispatch({
-        type: "error",
-        error: "The response stream closed before completion.",
-        request_id: dispatcher.lastRequestId() ?? options.requestId,
+    if (!aborted) {
+      const finalParsed = parseChatStreamChunk(buffer, decoder.decode(), {
+        ...parseOptions,
+        flush: true,
       });
+      buffer = finalParsed.bufferedRemainder;
+      for (const event of finalParsed.events) dispatcher.dispatch(event);
+
+      if (!dispatcher.sawTerminalEvent()) {
+        dispatcher.dispatch({
+          type: "error",
+          error: "The response stream closed before completion.",
+          request_id: dispatcher.lastRequestId() ?? options.requestId,
+        });
+      }
     }
   } finally {
     reader.releaseLock();

--- a/frontend/src/lib/chat-stream-events.test.ts
+++ b/frontend/src/lib/chat-stream-events.test.ts
@@ -41,6 +41,50 @@ describe("parseChatStreamChunk", () => {
   });
 });
 
+describe("parseChatStreamChunk overflow", () => {
+  it("propagates the overflow signal from the underlying SSE parser", () => {
+    const cap = 32;
+    const oversized = "data: " + "x".repeat(cap + 16);
+
+    const { events, bufferedRemainder, overflow } = parseChatStreamChunk("", oversized, {
+      maxBufferBytes: cap,
+    });
+
+    expect(events).toEqual([]);
+    expect(bufferedRemainder).toBe(oversized);
+    expect(overflow).toEqual({
+      bufferedBytes: oversized.length,
+      maxBufferBytes: cap,
+    });
+  });
+
+  it("dispatches a stream_overflow event through onStreamOverflow and treats it as terminal", () => {
+    const onStreamOverflow = vi.fn();
+    const onEvent = vi.fn();
+    const onError = vi.fn();
+    const dispatcher = createChatStreamDispatcher({
+      onStreamOverflow,
+      onEvent,
+      onError,
+    });
+
+    dispatcher.dispatch({
+      type: "stream_overflow",
+      bufferedBytes: 4_194_305,
+      maxBufferBytes: 4_194_304,
+    });
+
+    expect(onStreamOverflow).toHaveBeenCalledTimes(1);
+    const [arg] = onStreamOverflow.mock.calls[0];
+    expect(arg.type).toBe("stream_overflow");
+    expect(arg.bufferedBytes).toBe(4_194_305);
+    expect(arg.maxBufferBytes).toBe(4_194_304);
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(dispatcher.sawTerminalEvent()).toBe(true);
+  });
+});
+
 describe("parseChatStreamDataPayload", () => {
   it("preserves the raw payload when the JSON parser rejects it", () => {
     const event = parseChatStreamDataPayload("definitely not json");

--- a/frontend/src/lib/chat-stream-events.ts
+++ b/frontend/src/lib/chat-stream-events.ts
@@ -1,7 +1,8 @@
 import { parseRuntimeEvent } from "./runtime-events";
-import { parseSseChunk } from "./sse-parser";
+import { parseSseChunk, type SseOverflowSignal } from "./sse-parser";
 import type {
   ChatStreamEvent,
+  ChatStreamOverflowEvent,
   ChatStreamParseErrorEvent,
   ChatStreamPlanCreatedEvent,
   ChatStreamPlanUpdatedEvent,
@@ -15,10 +16,12 @@ import type {
 interface ParsedChatStreamChunk {
   bufferedRemainder: string;
   events: ChatStreamEvent[];
+  overflow?: SseOverflowSignal;
 }
 
 interface ParseChatStreamChunkOptions {
   flush?: boolean;
+  maxBufferBytes?: number;
 }
 
 function readOptionalString(value: unknown): string | undefined {
@@ -264,7 +267,7 @@ export function parseChatStreamChunk(
   decodedChunk: string,
   options: ParseChatStreamChunkOptions = {}
 ): ParsedChatStreamChunk {
-  const { bufferedRemainder, payloads } = parseSseChunk(
+  const { bufferedRemainder, payloads, overflow } = parseSseChunk(
     previousBuffer,
     decodedChunk,
     options
@@ -272,6 +275,7 @@ export function parseChatStreamChunk(
   return {
     bufferedRemainder,
     events: payloads.map(parseChatStreamDataPayload),
+    overflow,
   };
 }
 
@@ -304,6 +308,11 @@ export interface StreamCallbacks {
    * stream keeps running — malformed events are surfaced, not terminal.
    */
   onParseError?: (event: ChatStreamParseErrorEvent) => void;
+  /**
+   * Called when the SSE buffer cap is exceeded. Terminal: the transport will
+   * cancel the reader after dispatching this event.
+   */
+  onStreamOverflow?: (event: ChatStreamOverflowEvent) => void;
 }
 
 export interface ChatStreamDispatcher {
@@ -328,7 +337,11 @@ export function createChatStreamDispatcher(
     if (event.request_id) {
       lastRequestId = event.request_id;
     }
-    if (event.type === "done" || event.type === "error") {
+    if (
+      event.type === "done" ||
+      event.type === "error" ||
+      event.type === "stream_overflow"
+    ) {
       sawTerminalEvent = true;
     }
 
@@ -377,6 +390,9 @@ export function createChatStreamDispatcher(
         break;
       case "parse_error":
         callbacks.onParseError?.(event);
+        break;
+      case "stream_overflow":
+        callbacks.onStreamOverflow?.(event);
         break;
     }
   };

--- a/frontend/src/lib/chat-stream-reducer.ts
+++ b/frontend/src/lib/chat-stream-reducer.ts
@@ -227,6 +227,17 @@ export function applyStreamEvent(
         streamingMessageId: state.streamingMessageId,
         finished: false,
       };
+    case "stream_overflow":
+      return reduceErrorEvent(
+        state,
+        {
+          type: "error",
+          error: `SSE buffer overflow: ${event.bufferedBytes} bytes exceeded the ${event.maxBufferBytes}-byte cap.`,
+          request_id: event.request_id,
+          event_index: event.event_index,
+        },
+        options.now
+      );
   }
 }
 

--- a/frontend/src/lib/sse-parser.test.ts
+++ b/frontend/src/lib/sse-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseSseChunk } from "./sse-parser";
+import { DEFAULT_SSE_MAX_BUFFER_BYTES, parseSseChunk } from "./sse-parser";
 
 describe("parseSseChunk", () => {
   it("returns an empty result when no full event has been received yet", () => {
@@ -86,5 +86,59 @@ describe("parseSseChunk", () => {
     const result = parseSseChunk("", "data: {not-json}\n\n");
     expect(result.payloads).toEqual(["{not-json}"]);
     expect(result.bufferedRemainder).toBe("");
+  });
+
+  it("does not surface an overflow signal when the buffered remainder stays under the cap", () => {
+    const result = parseSseChunk("", "data: {\"type\":\"tok", { maxBufferBytes: 1024 });
+    expect(result.overflow).toBeUndefined();
+    expect(result.bufferedRemainder).toBe('data: {"type":"tok');
+  });
+
+  it("surfaces an overflow signal when the buffered remainder exceeds the cap", () => {
+    const cap = 64;
+    const oversized = "data: " + "x".repeat(cap + 16);
+    const result = parseSseChunk("", oversized, { maxBufferBytes: cap });
+    expect(result.payloads).toEqual([]);
+    expect(result.bufferedRemainder).toBe(oversized);
+    expect(result.overflow).toEqual({
+      bufferedBytes: oversized.length,
+      maxBufferBytes: cap,
+    });
+  });
+
+  it("still emits complete payloads alongside the overflow signal when the same chunk has both", () => {
+    const cap = 32;
+    const completed = 'data: {"type":"token","content":"a"}\n\n';
+    const oversizedTail = "data: " + "y".repeat(cap + 8);
+    const result = parseSseChunk("", completed + oversizedTail, { maxBufferBytes: cap });
+    expect(result.payloads).toEqual(['{"type":"token","content":"a"}']);
+    expect(result.bufferedRemainder).toBe(oversizedTail);
+    expect(result.overflow?.maxBufferBytes).toBe(cap);
+    expect(result.overflow?.bufferedBytes).toBe(oversizedTail.length);
+  });
+
+  it("uses the 4 MB default cap when none is passed", () => {
+    const justUnder = "x".repeat(DEFAULT_SSE_MAX_BUFFER_BYTES);
+    const underResult = parseSseChunk("", justUnder);
+    expect(underResult.overflow).toBeUndefined();
+
+    const justOver = "x".repeat(DEFAULT_SSE_MAX_BUFFER_BYTES + 1);
+    const overResult = parseSseChunk("", justOver);
+    expect(overResult.overflow?.maxBufferBytes).toBe(DEFAULT_SSE_MAX_BUFFER_BYTES);
+    expect(overResult.overflow?.bufferedBytes).toBe(DEFAULT_SSE_MAX_BUFFER_BYTES + 1);
+  });
+
+  it("trips the cap when an unterminated payload is fed in across multiple chunks", () => {
+    const cap = 128;
+    let buffer = "data: ";
+    let lastResult = parseSseChunk("", buffer, { maxBufferBytes: cap });
+    expect(lastResult.overflow).toBeUndefined();
+    buffer = lastResult.bufferedRemainder;
+    for (let i = 0; i < 4; i += 1) {
+      lastResult = parseSseChunk(buffer, "z".repeat(64), { maxBufferBytes: cap });
+      buffer = lastResult.bufferedRemainder;
+    }
+    expect(lastResult.overflow).toBeDefined();
+    expect(lastResult.overflow?.bufferedBytes).toBeGreaterThan(cap);
   });
 });

--- a/frontend/src/lib/sse-parser.ts
+++ b/frontend/src/lib/sse-parser.ts
@@ -8,6 +8,9 @@
  * responsibility of `chat-stream-events.ts`.
  */
 
+/** Default cap on the unterminated buffered remainder (4 MB). */
+export const DEFAULT_SSE_MAX_BUFFER_BYTES = 4 * 1024 * 1024;
+
 export interface SseParseOptions {
   /**
    * When the underlying stream ends without a trailing blank line, callers set
@@ -15,6 +18,22 @@ export interface SseParseOptions {
    * silently dropped.
    */
   flush?: boolean;
+  /**
+   * Cap (in characters, treated as a byte ballpark) on the unterminated
+   * `bufferedRemainder` carried between chunks. When exceeded, the parser
+   * still returns the remainder and any complete payloads from this chunk,
+   * but also surfaces an `overflow` signal so callers can abort the stream
+   * before unbounded memory growth turns into a DoS. Defaults to
+   * `DEFAULT_SSE_MAX_BUFFER_BYTES` (4 MB). Pass `Infinity` to disable.
+   */
+  maxBufferBytes?: number;
+}
+
+export interface SseOverflowSignal {
+  /** Size of the unterminated remainder that tripped the cap. */
+  bufferedBytes: number;
+  /** The cap value that was exceeded. */
+  maxBufferBytes: number;
 }
 
 export interface SseParseResult {
@@ -22,6 +41,12 @@ export interface SseParseResult {
   bufferedRemainder: string;
   /** Raw text of every `data:` line surfaced during this call. */
   payloads: string[];
+  /**
+   * Set when the unterminated remainder exceeded `maxBufferBytes`. Callers
+   * should treat this as a terminal signal — typically dispatch a synthetic
+   * overflow event and cancel the reader.
+   */
+  overflow?: SseOverflowSignal;
 }
 
 const DATA_PREFIX = "data: ";
@@ -50,8 +75,21 @@ export function parseSseChunk(
     }
   }
 
+  const bufferedRemainder = shouldFlushPending ? "" : pending;
+  const maxBufferBytes = options.maxBufferBytes ?? DEFAULT_SSE_MAX_BUFFER_BYTES;
+  if (bufferedRemainder.length > maxBufferBytes) {
+    return {
+      bufferedRemainder,
+      payloads,
+      overflow: {
+        bufferedBytes: bufferedRemainder.length,
+        maxBufferBytes,
+      },
+    };
+  }
+
   return {
-    bufferedRemainder: shouldFlushPending ? "" : pending,
+    bufferedRemainder,
     payloads,
   };
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -240,6 +240,20 @@ export interface ChatStreamParseErrorEvent {
   raw?: string;
 }
 
+/**
+ * Client-side synthetic event emitted when the SSE parser's buffered remainder
+ * grows past the configured cap (default 4 MB) without a record terminator.
+ * The transport treats this as terminal and cancels the reader to defend
+ * against a memory-exhaustion DoS.
+ */
+export interface ChatStreamOverflowEvent {
+  request_id?: string;
+  event_index?: number;
+  type: "stream_overflow";
+  bufferedBytes: number;
+  maxBufferBytes: number;
+}
+
 export interface ChatStreamWarningEvent {
   request_id?: string;
   event_index?: number;
@@ -270,7 +284,8 @@ export type ChatStreamEvent =
   | ChatStreamWorkflowStepStartedEvent
   | ChatStreamWorkflowStepEndedEvent
   | ChatStreamWorkflowStepFailedEvent
-  | ChatStreamParseErrorEvent;
+  | ChatStreamParseErrorEvent
+  | ChatStreamOverflowEvent;
 
 export type ChatStreamEventType = ChatStreamEvent["type"];
 


### PR DESCRIPTION
Closes #96

Opened by the personal automation loop. Draft until human-reviewed.