### PR TITLE
auto: #97 Persist bearer tokens across refresh

### DIFF
--- a/frontend/src/lib/auth-storage.test.ts
+++ b/frontend/src/lib/auth-storage.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearApiAuthState,
+  getStorageBaseUrl,
+  loadApiAuthState,
+  saveApiAuthState,
+} from "./auth-storage";
+
+const EMPTY = {
+  inspectionBearerToken: null,
+  executionBearerToken: null,
+  adminBearerToken: null,
+};
+
+describe("auth-storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns an empty auth state when nothing is stored", () => {
+    expect(loadApiAuthState()).toEqual(EMPTY);
+  });
+
+  it("round-trips an ApiAuthState through save/load for the current base URL", () => {
+    saveApiAuthState({
+      inspectionBearerToken: "inspect-abc",
+      executionBearerToken: "exec-xyz",
+      adminBearerToken: "admin-123",
+    });
+
+    expect(loadApiAuthState()).toEqual({
+      inspectionBearerToken: "inspect-abc",
+      executionBearerToken: "exec-xyz",
+      adminBearerToken: "admin-123",
+    });
+  });
+
+  it("keeps tokens isolated between backend base URLs", () => {
+    const firstBase = "http://host-a:8002";
+    const secondBase = "http://host-b:8002";
+
+    saveApiAuthState(
+      {
+        inspectionBearerToken: "a-inspect",
+        executionBearerToken: null,
+        adminBearerToken: null,
+      },
+      firstBase,
+    );
+    saveApiAuthState(
+      {
+        inspectionBearerToken: "b-inspect",
+        executionBearerToken: "b-exec",
+        adminBearerToken: null,
+      },
+      secondBase,
+    );
+
+    expect(loadApiAuthState(firstBase)).toEqual({
+      inspectionBearerToken: "a-inspect",
+      executionBearerToken: null,
+      adminBearerToken: null,
+    });
+    expect(loadApiAuthState(secondBase)).toEqual({
+      inspectionBearerToken: "b-inspect",
+      executionBearerToken: "b-exec",
+      adminBearerToken: null,
+    });
+  });
+
+  it("removes the stored entry when clearApiAuthState runs", () => {
+    saveApiAuthState({
+      inspectionBearerToken: "will-be-cleared",
+      executionBearerToken: null,
+      adminBearerToken: null,
+    });
+
+    const base = getStorageBaseUrl();
+    const hasEntryForBase = (): boolean =>
+      Object.keys(window.localStorage).some((key) => key.includes(base));
+
+    expect(hasEntryForBase()).toBe(true);
+
+    clearApiAuthState();
+
+    expect(hasEntryForBase()).toBe(false);
+    expect(loadApiAuthState()).toEqual(EMPTY);
+  });
+
+  it("does not leak tokens across base URLs when one is cleared", () => {
+    const firstBase = "http://host-a:8002";
+    const secondBase = "http://host-b:8002";
+
+    saveApiAuthState(
+      {
+        inspectionBearerToken: "a-inspect",
+        executionBearerToken: null,
+        adminBearerToken: null,
+      },
+      firstBase,
+    );
+    saveApiAuthState(
+      {
+        inspectionBearerToken: "b-inspect",
+        executionBearerToken: null,
+        adminBearerToken: null,
+      },
+      secondBase,
+    );
+
+    clearApiAuthState(firstBase);
+
+    expect(loadApiAuthState(firstBase)).toEqual(EMPTY);
+    expect(loadApiAuthState(secondBase).inspectionBearerToken).toBe("b-inspect");
+  });
+
+  it("ignores corrupted JSON and returns an empty auth state", () => {
+    const base = getStorageBaseUrl();
+    window.localStorage.setItem(`bioapex.apiAuth.v1:${base}`, "{not json");
+
+    expect(loadApiAuthState()).toEqual(EMPTY);
+  });
+});

--- a/frontend/src/lib/auth-storage.ts
+++ b/frontend/src/lib/auth-storage.ts
@@ -1,0 +1,95 @@
+import { EMPTY_API_AUTH_STATE } from "./access-control";
+import type { ApiAuthState } from "./api";
+
+// Versioned prefix so a future shape change can land without colliding with
+// previously-stored entries. The key also includes the backend base URL so
+// tokens remain isolated when the same browser talks to several backends.
+const STORAGE_KEY_PREFIX = "bioapex.apiAuth.v1:";
+
+/**
+ * Mirrors getBase() in ./api.ts. Kept local to avoid widening that module's
+ * public surface just for storage keying.
+ */
+export function getStorageBaseUrl(): string {
+  if (typeof window === "undefined") return "http://localhost:8002";
+  return `http://${window.location.hostname}:8002`;
+}
+
+function getStorageKey(baseUrl: string): string {
+  return `${STORAGE_KEY_PREFIX}${baseUrl}`;
+}
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeToken(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeAuthState(value: unknown): ApiAuthState {
+  if (!value || typeof value !== "object") {
+    return { ...EMPTY_API_AUTH_STATE };
+  }
+  const record = value as Record<string, unknown>;
+  return {
+    inspectionBearerToken: sanitizeToken(record.inspectionBearerToken),
+    executionBearerToken: sanitizeToken(record.executionBearerToken),
+    adminBearerToken: sanitizeToken(record.adminBearerToken),
+  };
+}
+
+export function loadApiAuthState(
+  baseUrl: string = getStorageBaseUrl(),
+): ApiAuthState {
+  const storage = getStorage();
+  if (!storage) return { ...EMPTY_API_AUTH_STATE };
+  let raw: string | null;
+  try {
+    raw = storage.getItem(getStorageKey(baseUrl));
+  } catch {
+    return { ...EMPTY_API_AUTH_STATE };
+  }
+  if (!raw) return { ...EMPTY_API_AUTH_STATE };
+  try {
+    return normalizeAuthState(JSON.parse(raw));
+  } catch {
+    return { ...EMPTY_API_AUTH_STATE };
+  }
+}
+
+export function saveApiAuthState(
+  authState: ApiAuthState,
+  baseUrl: string = getStorageBaseUrl(),
+): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(
+      getStorageKey(baseUrl),
+      JSON.stringify(normalizeAuthState(authState)),
+    );
+  } catch {
+    // Storage may be disabled (private mode) or full — fall back to in-memory
+    // state rather than breaking the sign-in flow.
+  }
+}
+
+export function clearApiAuthState(
+  baseUrl: string = getStorageBaseUrl(),
+): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(getStorageKey(baseUrl));
+  } catch {
+    // See saveApiAuthState.
+  }
+}

--- a/frontend/src/lib/store.tsx
+++ b/frontend/src/lib/store.tsx
@@ -15,6 +15,11 @@ import {
   withScopeBearerToken,
 } from "./access-control";
 import * as api from "./api";
+import {
+  clearApiAuthState,
+  loadApiAuthState,
+  saveApiAuthState,
+} from "./auth-storage";
 import { useAccessScopeState } from "./access-scope-state";
 import {
   useSessionCatalog,
@@ -121,6 +126,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const apiAuthStateRef = useRef(apiAuthState);
 
   useEffect(() => {
+    // Hydrate persisted bearer tokens keyed by backend base URL so reloads
+    // don't force the user back through sign-in. Runs once on mount (client
+    // only) — the server-render pass leaves the empty initial state intact.
+    setApiAuthState(loadApiAuthState());
     setHasLoadedApiAuthState(true);
   }, []);
 
@@ -192,10 +201,15 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const setAccessToken = useCallback((scope: AccessScope, token: string) => {
-    setApiAuthState((current) => withScopeBearerToken(current, scope, token));
+    setApiAuthState((current) => {
+      const next = withScopeBearerToken(current, scope, token);
+      saveApiAuthState(next);
+      return next;
+    });
   }, []);
 
   const clearAccessTokens = useCallback(() => {
+    clearApiAuthState();
     setApiAuthState(clearAllBearerTokens());
   }, []);
 


### PR DESCRIPTION
Closes #97

Opened by the personal automation loop. Draft until human-reviewed.