### PR TITLE
auto: #102 Request-id correlation / stale-response guard

### DIFF
--- a/frontend/src/components/editor/panels/UsagePanel.test.tsx
+++ b/frontend/src/components/editor/panels/UsagePanel.test.tsx
@@ -68,6 +68,36 @@ describe("UsagePanel", () => {
     expect(screen.getByText("3")).toBeTruthy();
   });
 
+  it("shows the request-id drop counter once the dispatcher has dropped a stale event", () => {
+    const messages: Message[] = [
+      {
+        id: "user-1",
+        role: "user",
+        content: "hi",
+        blocks: [{ type: "text", text: "hi" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "hello",
+        blocks: [{ type: "text", text: "hello" }],
+      },
+    ];
+
+    vi.mocked(useApp).mockReturnValue(
+      makeMockAppValue({
+        currentSessionId: "session-stale",
+        messages,
+        requestIdMismatchCount: 2,
+      })
+    );
+
+    render(<UsagePanel />);
+
+    expect(screen.getByText("Request-id drops")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+  });
+
   it("omits the parse-error row when no malformed payloads have been seen", () => {
     const messages: Message[] = [
       {
@@ -95,5 +125,6 @@ describe("UsagePanel", () => {
     render(<UsagePanel />);
 
     expect(screen.queryByText("Parse errors")).toBeNull();
+    expect(screen.queryByText("Request-id drops")).toBeNull();
   });
 });

--- a/frontend/src/components/editor/panels/UsagePanel.tsx
+++ b/frontend/src/components/editor/panels/UsagePanel.tsx
@@ -25,6 +25,7 @@ export default function UsagePanel() {
     messages,
     isStreaming,
     parseErrorCount,
+    requestIdMismatchCount,
   } = useApp();
 
   const [tokens, setTokens] = useState<TokenStats | null>(null);
@@ -177,6 +178,12 @@ export default function UsagePanel() {
                 <UsageMetricRow
                   label="Parse errors"
                   value={parseErrorCount.toLocaleString()}
+                />
+              ) : null}
+              {requestIdMismatchCount > 0 ? (
+                <UsageMetricRow
+                  label="Request-id drops"
+                  value={requestIdMismatchCount.toLocaleString()}
                 />
               ) : null}
             </div>

--- a/frontend/src/lib/api.stream-chat.test.ts
+++ b/frontend/src/lib/api.stream-chat.test.ts
@@ -446,6 +446,64 @@ describe("streamChat", () => {
     expect(surfacedErrors).toEqual([]);
   });
 
+  it("drops events whose request_id does not match the latched in-flight id", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      sseResponse(
+        [
+          {
+            type: "token",
+            content: "first ",
+            request_id: "request-live",
+            event_index: 1,
+          },
+          {
+            type: "token",
+            content: "stale-echo",
+            request_id: "request-stale",
+            event_index: 2,
+          },
+          { type: "token", content: "untagged ", event_index: 3 },
+          {
+            type: "done",
+            content: "first untagged done.",
+            request_id: "request-live",
+            event_index: 4,
+          },
+        ],
+        { chunkSize: 29 }
+      )
+    );
+
+    const tokens: string[] = [];
+    const mismatchRequestIds: string[] = [];
+    let finalContent = "";
+    let finalRequestId = "";
+
+    await streamChat(
+      "Ignore the stale echo.",
+      "session-stale",
+      {
+        onToken: (content) => {
+          tokens.push(content);
+        },
+        onDone: (content, requestId) => {
+          finalContent = content;
+          finalRequestId = requestId ?? "";
+        },
+        onRequestIdMismatch: (event) => {
+          if (event.request_id) {
+            mismatchRequestIds.push(event.request_id);
+          }
+        },
+      }
+    );
+
+    expect(tokens).toEqual(["first ", "untagged "]);
+    expect(mismatchRequestIds).toEqual(["request-stale"]);
+    expect(finalContent).toBe("first untagged done.");
+    expect(finalRequestId).toBe("request-live");
+  });
+
   it("cancels the in-flight fetch when the AbortController is aborted", async () => {
     let receivedSignal: AbortSignal | undefined;
 

--- a/frontend/src/lib/chat-stream-events.test.ts
+++ b/frontend/src/lib/chat-stream-events.test.ts
@@ -85,6 +85,108 @@ describe("parseChatStreamChunk overflow", () => {
   });
 });
 
+describe("createChatStreamDispatcher request-id correlation", () => {
+  it("latches on to the first request_id and applies events that match", () => {
+    const onEvent = vi.fn();
+    const onRequestIdMismatch = vi.fn();
+    const onToken = vi.fn();
+    const dispatcher = createChatStreamDispatcher({
+      onEvent,
+      onToken,
+      onRequestIdMismatch,
+    });
+
+    dispatcher.dispatch({ type: "token", content: "hello ", request_id: "req-1" });
+    dispatcher.dispatch({ type: "token", content: "world", request_id: "req-1" });
+
+    expect(onEvent).toHaveBeenCalledTimes(2);
+    expect(onToken).toHaveBeenNthCalledWith(1, "hello ");
+    expect(onToken).toHaveBeenNthCalledWith(2, "world");
+    expect(onRequestIdMismatch).not.toHaveBeenCalled();
+    expect(dispatcher.expectedRequestId()).toBe("req-1");
+  });
+
+  it("drops subsequent events that carry a mismatched request_id", () => {
+    const onEvent = vi.fn();
+    const onToken = vi.fn();
+    const onRequestIdMismatch = vi.fn();
+    const dispatcher = createChatStreamDispatcher({
+      onEvent,
+      onToken,
+      onRequestIdMismatch,
+    });
+
+    dispatcher.dispatch({ type: "token", content: "first", request_id: "req-1" });
+    dispatcher.dispatch({
+      type: "token",
+      content: "stale echo",
+      request_id: "req-stale",
+    });
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onToken).toHaveBeenCalledTimes(1);
+    expect(onToken).toHaveBeenCalledWith("first");
+    expect(onRequestIdMismatch).toHaveBeenCalledTimes(1);
+    const [droppedEvent] = onRequestIdMismatch.mock.calls[0];
+    expect(droppedEvent.type).toBe("token");
+    expect(droppedEvent.request_id).toBe("req-stale");
+    expect(dispatcher.expectedRequestId()).toBe("req-1");
+  });
+
+  it("applies events without a request_id regardless of the latched id", () => {
+    const onEvent = vi.fn();
+    const onToken = vi.fn();
+    const onRequestIdMismatch = vi.fn();
+    const dispatcher = createChatStreamDispatcher({
+      onEvent,
+      onToken,
+      onRequestIdMismatch,
+    });
+
+    dispatcher.dispatch({ type: "token", content: "pinned", request_id: "req-1" });
+    dispatcher.dispatch({ type: "token", content: "no-id-token" });
+
+    expect(onEvent).toHaveBeenCalledTimes(2);
+    expect(onToken).toHaveBeenNthCalledWith(2, "no-id-token");
+    expect(onRequestIdMismatch).not.toHaveBeenCalled();
+  });
+
+  it("applies events when no expected id has been set yet", () => {
+    const onEvent = vi.fn();
+    const onToken = vi.fn();
+    const onRequestIdMismatch = vi.fn();
+    const dispatcher = createChatStreamDispatcher({
+      onEvent,
+      onToken,
+      onRequestIdMismatch,
+    });
+
+    dispatcher.dispatch({ type: "token", content: "before-id" });
+    dispatcher.dispatch({ type: "token", content: "also-before-id" });
+
+    expect(onEvent).toHaveBeenCalledTimes(2);
+    expect(onRequestIdMismatch).not.toHaveBeenCalled();
+    expect(dispatcher.expectedRequestId()).toBeUndefined();
+  });
+
+  it("honors a pre-seeded expected request id", () => {
+    const onEvent = vi.fn();
+    const onRequestIdMismatch = vi.fn();
+    const dispatcher = createChatStreamDispatcher(
+      { onEvent, onRequestIdMismatch },
+      { expectedRequestId: "req-seeded" }
+    );
+
+    dispatcher.dispatch({ type: "token", content: "match", request_id: "req-seeded" });
+    dispatcher.dispatch({ type: "token", content: "drop", request_id: "req-other" });
+    dispatcher.dispatch({ type: "token", content: "always-apply" });
+
+    expect(onEvent).toHaveBeenCalledTimes(2);
+    expect(onRequestIdMismatch).toHaveBeenCalledTimes(1);
+    expect(dispatcher.expectedRequestId()).toBe("req-seeded");
+  });
+});
+
 describe("parseChatStreamDataPayload", () => {
   it("preserves the raw payload when the JSON parser rejects it", () => {
     const event = parseChatStreamDataPayload("definitely not json");

--- a/frontend/src/lib/chat-stream-events.ts
+++ b/frontend/src/lib/chat-stream-events.ts
@@ -313,12 +313,31 @@ export interface StreamCallbacks {
    * cancel the reader after dispatching this event.
    */
   onStreamOverflow?: (event: ChatStreamOverflowEvent) => void;
+  /**
+   * Called when an incoming event carries a `request_id` that doesn't match
+   * the one the dispatcher latched on to for this stream. The event is
+   * dropped before any other callback runs so stale-response payloads never
+   * reach the reducer.
+   */
+  onRequestIdMismatch?: (event: ChatStreamEvent) => void;
 }
 
 export interface ChatStreamDispatcher {
   dispatch: (event: ChatStreamEvent) => void;
   sawTerminalEvent: () => boolean;
   lastRequestId: () => string | undefined;
+  expectedRequestId: () => string | undefined;
+}
+
+export interface CreateChatStreamDispatcherOptions {
+  /**
+   * Pre-seed the expected request id. When set, any event whose
+   * `request_id` is present and differs is dropped as a stale response
+   * before callbacks run. When omitted, the dispatcher latches on to the
+   * first backend-emitted `request_id` it sees and compares subsequent
+   * events against it.
+   */
+  expectedRequestId?: string;
 }
 
 /**
@@ -328,13 +347,21 @@ export interface ChatStreamDispatcher {
  * + reader loop.
  */
 export function createChatStreamDispatcher(
-  callbacks: StreamCallbacks
+  callbacks: StreamCallbacks,
+  options: CreateChatStreamDispatcherOptions = {}
 ): ChatStreamDispatcher {
   let sawTerminalEvent = false;
   let lastRequestId: string | undefined;
+  let expectedRequestId: string | undefined = options.expectedRequestId;
 
   const dispatch = (event: ChatStreamEvent) => {
     if (event.request_id) {
+      if (expectedRequestId === undefined) {
+        expectedRequestId = event.request_id;
+      } else if (event.request_id !== expectedRequestId) {
+        callbacks.onRequestIdMismatch?.(event);
+        return;
+      }
       lastRequestId = event.request_id;
     }
     if (
@@ -401,5 +428,6 @@ export function createChatStreamDispatcher(
     dispatch,
     sawTerminalEvent: () => sawTerminalEvent,
     lastRequestId: () => lastRequestId,
+    expectedRequestId: () => expectedRequestId,
   };
 }

--- a/frontend/src/lib/chat-turn-runner.ts
+++ b/frontend/src/lib/chat-turn-runner.ts
@@ -33,6 +33,12 @@ export interface ChatTurnCallbacks {
    * UsagePanel can surface dropped-event telemetry.
    */
   onParseError?: (event: ChatStreamParseErrorEvent) => void;
+  /**
+   * Fired when the stream dispatcher drops an event because its
+   * `request_id` doesn't match the one latched for this turn. Used by the
+   * catalog to maintain a session-level counter alongside parse errors.
+   */
+  onRequestIdMismatch?: (event: ChatStreamEvent) => void;
 }
 
 export interface RunChatTurnParams {
@@ -120,6 +126,9 @@ export async function runChatTurn({
       {
         signal: abortController.signal,
         onEvent: applyAndCommitEvent,
+        onRequestIdMismatch: (event) => {
+          callbacks.onRequestIdMismatch?.(event);
+        },
       },
       { requestId }
     );

--- a/frontend/src/lib/session-catalog.ts
+++ b/frontend/src/lib/session-catalog.ts
@@ -62,6 +62,12 @@ export interface UseSessionCatalogResult {
    * turns so UsagePanel can show cumulative drop telemetry.
    */
   parseErrorCount: number;
+  /**
+   * Number of stream events the dispatcher dropped because their
+   * `request_id` didn't match the in-flight turn. Resets on session
+   * switch; parallels `parseErrorCount` in UsagePanel.
+   */
+  requestIdMismatchCount: number;
   refreshSessions: () => Promise<void>;
   reloadCurrentSession: () => Promise<void>;
   createSession: () => Promise<void>;
@@ -106,6 +112,7 @@ export function useSessionCatalog(
     null
   );
   const [parseErrorCount, setParseErrorCount] = useState(0);
+  const [requestIdMismatchCount, setRequestIdMismatchCount] = useState(0);
 
   const streamingIdRef = useRef<string | null>(null);
   const streamAbortControllerRef = useRef<AbortController | null>(null);
@@ -163,6 +170,7 @@ export function useSessionCatalog(
     setSessionHistoryError(null);
     setSessionContinuitySummaries([]);
     setParseErrorCount(0);
+    setRequestIdMismatchCount(0);
   }, [accessByScope.inspection.status, hasLoadedApiAuthState]);
 
   // Load session list and rehydrate current session once inspection access arrives.
@@ -322,6 +330,7 @@ export function useSessionCatalog(
     setSessionHistoryError(null);
     setSessionContinuitySummaries([]);
     setParseErrorCount(0);
+    setRequestIdMismatchCount(0);
     resetDraftAndInspector();
   }, [hasExecutionAccess, resetDraftAndInspector]);
 
@@ -341,6 +350,7 @@ export function useSessionCatalog(
           getSessionHistoryErrorMessage
         );
         setParseErrorCount(0);
+    setRequestIdMismatchCount(0);
         resetDraftAndInspector();
       } catch (error) {
         promoteInspectionScopeError(error);
@@ -368,6 +378,7 @@ export function useSessionCatalog(
         setSessionHistoryError(null);
         setSessionContinuitySummaries([]);
         setParseErrorCount(0);
+    setRequestIdMismatchCount(0);
         resetDraftAndInspector();
       }
     },
@@ -503,6 +514,9 @@ export function useSessionCatalog(
           onParseError: () => {
             setParseErrorCount((count) => count + 1);
           },
+          onRequestIdMismatch: () => {
+            setRequestIdMismatchCount((count) => count + 1);
+          },
         },
       });
     },
@@ -541,6 +555,7 @@ export function useSessionCatalog(
     sessionContinuitySummaries,
     lastFailedTurn,
     parseErrorCount,
+    requestIdMismatchCount,
     refreshSessions,
     reloadCurrentSession,
     createSession,

--- a/frontend/src/lib/store.tsx
+++ b/frontend/src/lib/store.tsx
@@ -69,6 +69,12 @@ interface AppContextValue {
    * observable instead of silently swallowed.
    */
   parseErrorCount: number;
+  /**
+   * Count of events the dispatcher dropped because their `request_id`
+   * didn't match the in-flight turn. Surfaced beside `parseErrorCount` in
+   * UsagePanel so stale-response drops are observable.
+   */
+  requestIdMismatchCount: number;
   draftMessage: string;
   draftRevision: number;
   inspectorTab: InspectorTab;
@@ -276,6 +282,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       sessionContinuitySummaries: catalog.sessionContinuitySummaries,
       lastFailedTurn: catalog.lastFailedTurn,
       parseErrorCount: catalog.parseErrorCount,
+      requestIdMismatchCount: catalog.requestIdMismatchCount,
       draftMessage,
       draftRevision,
       inspectorTab,
@@ -317,6 +324,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       catalog.sessionContinuitySummaries,
       catalog.lastFailedTurn,
       catalog.parseErrorCount,
+      catalog.requestIdMismatchCount,
       catalog.refreshSessions,
       catalog.reloadCurrentSession,
       catalog.createSession,

--- a/frontend/src/test/panel-fixtures.ts
+++ b/frontend/src/test/panel-fixtures.ts
@@ -34,6 +34,7 @@ export function makeMockAppValue(
     sessionContinuitySummaries: [],
     lastFailedTurn: null,
     parseErrorCount: 0,
+    requestIdMismatchCount: 0,
     draftMessage: "",
     draftRevision: 0,
     inspectorTab: "files",


### PR DESCRIPTION
Closes #102

Opened by the personal automation loop. Draft until human-reviewed.