### PR TITLE
auto: #108 Atomic session file write (avoid mid-write corruption)

### DIFF
--- a/backend/graph/session/session_archive.py
+++ b/backend/graph/session/session_archive.py
@@ -10,6 +10,7 @@ import time
 from typing import Any
 
 from graph.session.session_archive_index import (
+    _atomic_write_text,
     append_archive_entry,
     list_archive_entries,
 )
@@ -110,8 +111,8 @@ class SessionManager(SessionStore):
         # Write archive file
         archive_id = str(time.time_ns())
         archive_path = self.archive_dir / f"{session_id}_{archive_id}.json"
-        archive_path.write_text(
-            json.dumps(archived, ensure_ascii=False, indent=2), encoding="utf-8"
+        _atomic_write_text(
+            archive_path, json.dumps(archived, ensure_ascii=False, indent=2)
         )
 
         # Update the on-disk sidecar so ``list_archived_history_batches`` can

--- a/backend/graph/session/session_archive_index.py
+++ b/backend/graph/session/session_archive_index.py
@@ -101,6 +101,20 @@ def _normalize_loaded_index(raw: Any) -> dict[str, list[ArchiveIndexEntry]] | No
     return normalized
 
 
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write *text* to *path* atomically via ``<name>.tmp`` + rename.
+
+    A crash between the tmp-file write and the rename leaves the original
+    file untouched; callers that read with decode-error tolerance then see
+    the last good version instead of a truncated file. Callers in the
+    session package go through this helper so session JSON, archive batch
+    files, and the archive-index sidecar all share the same guarantee.
+    """
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)
+
+
 def _write_index(
     archive_dir: Path, index: dict[str, list[ArchiveIndexEntry]]
 ) -> None:
@@ -110,9 +124,7 @@ def _write_index(
         "schema_version": ARCHIVE_INDEX_SCHEMA_VERSION,
         "sessions": index,
     }
-    tmp = path.with_name(path.name + ".tmp")
-    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
-    tmp.replace(path)
+    _atomic_write_text(path, json.dumps(payload, ensure_ascii=False, indent=2))
 
 
 def _load_index(archive_dir: Path) -> dict[str, list[ArchiveIndexEntry]]:

--- a/backend/graph/session/session_store.py
+++ b/backend/graph/session/session_store.py
@@ -11,7 +11,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
-from graph.session.session_archive_index import remove_session_from_index
+from graph.session.session_archive_index import (
+    _atomic_write_text,
+    remove_session_from_index,
+)
 from graph.session.session_normalizer import (
     _build_blocks_from_legacy_message,
     _normalize_blocks,
@@ -87,9 +90,16 @@ class SessionStore:
 
         try:
             raw = json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError) as exc:
             # Corrupted or unreadable file — return a fresh session structure
-            # rather than propagating a 500 error to the user.
+            # rather than propagating a 500 error to the user. Log so
+            # silent data loss from a truncated write is visible in ops.
+            logger.warning(
+                "session_read_fallback session_id=%s path=%s error=%s",
+                session_id,
+                path,
+                exc,
+            )
             return self._empty(session_id)
 
         # v1 migration: plain list → v2 dict
@@ -110,8 +120,9 @@ class SessionStore:
         data.setdefault("schema_version", SESSION_SCHEMA_VERSION)
         data["updated_at"] = time.time()
         self._stamp_deterministic_mode(data)
-        self._path(session_id).write_text(
-            json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+        _atomic_write_text(
+            self._path(session_id),
+            json.dumps(data, ensure_ascii=False, indent=2),
         )
 
     @staticmethod

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -932,3 +932,109 @@ class TestDeleteSessionDistillationHook:
         assert not (tmp_path / "sessions" / f"{session_id}.json").exists()
         # Failure is surfaced via the in-memory set the debug endpoint exposes.
         assert session_id in get_failed_distillations()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Atomic session writes (tmp-file + rename)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestAtomicSessionWrite:
+    """Session writes must go through tmp-file + rename so a crash between
+    the write and the rename leaves the prior file intact — not truncated
+    into silent data loss.
+    """
+
+    def test_crash_between_tmp_write_and_rename_preserves_original_session(
+        self, sm, tmp_path, monkeypatch
+    ):
+        sid = sm.create_session()
+        sm.save_message(sid, "user", "first durable message")
+        sm.save_message(sid, "assistant", "first durable reply")
+
+        session_path = tmp_path / "sessions" / f"{sid}.json"
+        original_bytes = session_path.read_bytes()
+
+        real_replace = Path.replace
+
+        def exploding_replace(self, target):
+            if str(self).endswith(f"{sid}.json.tmp"):
+                raise OSError("simulated crash between tmp write and rename")
+            return real_replace(self, target)
+
+        monkeypatch.setattr(Path, "replace", exploding_replace)
+
+        with pytest.raises(OSError):
+            sm.save_message(sid, "user", "write that never lands")
+
+        # Original file untouched (same bytes) — the aborted write did not
+        # truncate it, and no empty session was silently persisted.
+        assert session_path.read_bytes() == original_bytes
+        # And a straggling *.tmp must not masquerade as the session file.
+        assert not (tmp_path / "sessions" / f"{sid}.json.tmp").exists() or (
+            tmp_path / "sessions" / f"{sid}.json.tmp"
+        ).read_bytes() != b""
+
+        monkeypatch.undo()
+
+        # After the crash path is cleared, reads return the original history
+        # rather than the empty-session fallback.
+        msgs = sm.load_session(sid)
+        assert [m["content"] for m in msgs] == [
+            "first durable message",
+            "first durable reply",
+        ]
+        assert sm.get_session_meta(sid)["message_count"] == 2
+
+    def test_crash_during_archive_write_preserves_prior_session_state(
+        self, sm, tmp_path, monkeypatch
+    ):
+        sid = sm.create_session()
+        for i in range(6):
+            sm.save_message(sid, "user" if i % 2 == 0 else "assistant", f"msg{i}")
+
+        session_path = tmp_path / "sessions" / f"{sid}.json"
+        original_bytes = session_path.read_bytes()
+        archive_dir = tmp_path / "sessions" / "archive"
+
+        real_replace = Path.replace
+
+        def exploding_replace(self, target):
+            # Fail only on archive batch writes (ignore the session JSON
+            # and the _index.json sidecar so the simulated crash is scoped
+            # to the archive batch file itself).
+            if str(self).endswith(".json.tmp") and f"{sid}_" in self.name:
+                raise OSError("simulated crash writing archive batch")
+            return real_replace(self, target)
+
+        monkeypatch.setattr(Path, "replace", exploding_replace)
+
+        with pytest.raises(OSError):
+            sm.compress_history(sid, "summary", 4)
+
+        # Session file untouched (compress_history never reached _write).
+        assert session_path.read_bytes() == original_bytes
+
+        monkeypatch.undo()
+
+        # All messages still readable after the aborted compression.
+        msgs = sm.load_session(sid)
+        assert len(msgs) == 6
+        # No partial archive batch file exists for this session.
+        assert not list(archive_dir.glob(f"{sid}_*.json"))
+
+    def test_read_fallback_logs_when_session_file_is_corrupt(
+        self, sm, tmp_path, caplog
+    ):
+        sid = sm.create_session()
+        session_path = tmp_path / "sessions" / f"{sid}.json"
+        # Simulate a truncated/corrupt write on disk.
+        session_path.write_text("{not valid json", encoding="utf-8")
+
+        with caplog.at_level("WARNING", logger="graph.session.session_store"):
+            result = sm.load_session(sid)
+
+        assert result == []
+        assert any(
+            "session_read_fallback" in record.message for record in caplog.records
+        )


### PR DESCRIPTION
Closes #108

Opened by the personal automation loop. Draft until human-reviewed.