### PR TITLE
auto: #129 Persist full tool output as an artifact; keep preview in transcript

### DIFF
--- a/backend/api/files.py
+++ b/backend/api/files.py
@@ -36,8 +36,17 @@ from starlette.requests import ClientDisconnect
 
 router = APIRouter()
 
-# Paths the API is allowed to serve (relative to base_dir)
-_READ_ALLOWED_PREFIXES = ("workspace/", "memory/", "skills/", "knowledge/", "artifacts/")
+# Paths the API is allowed to serve (relative to base_dir).
+# ``storage/tool-outputs/`` is included so the chat UI can fetch the full-text
+# spill file linked from a ``tool_output_overflow`` ToolArtifactRef (issue #129).
+_READ_ALLOWED_PREFIXES = (
+    "workspace/",
+    "memory/",
+    "skills/",
+    "knowledge/",
+    "artifacts/",
+    "storage/tool-outputs/",
+)
 _WRITE_ALLOWED_PREFIXES = ("workspace/", "memory/", "skills/", "knowledge/")
 # Streamed writes are gated strictly to artifacts/ so the editor POST whitelist
 # is not widened for large, tool-produced payloads.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,10 +5,11 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _isolated_tool_trace_dir(monkeypatch, tmp_path):
-    """Redirect tool-trace JSONL writes to a per-test tmp directory.
+    """Redirect tool-trace and tool-output-overflow writes into tmp.
 
-    The production default writes under ``backend/storage/tool-traces/``; tests
-    should not touch that location.
+    The production defaults write under ``backend/storage/tool-traces/`` and
+    ``backend/storage/tool-outputs/``. Tests should not touch those locations.
     """
     monkeypatch.setenv("BIOAPEX_TOOL_TRACE_DIR", str(tmp_path / "tool-traces"))
+    monkeypatch.setenv("BIOAPEX_TOOL_OUTPUT_DIR", str(tmp_path / "tool-outputs"))
     yield

--- a/backend/tests/test_tool_output_overflow.py
+++ b/backend/tests/test_tool_output_overflow.py
@@ -1,0 +1,181 @@
+"""Large tool outputs spill to an artifact and keep a transcript preview.
+
+Regression coverage for issue #129: when a tool returns a summary that
+blows the transcript budget, PolicyWrappedTool must persist the full
+content to disk, append a typed ``tool_output_overflow`` artifact ref, and
+leave a truncated preview in the envelope.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from langchain_core.tools import BaseTool
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools.contracts import MAX_STRUCTURED_PAYLOAD_JSON_CHARS
+from tools.policy import tool_policy_context
+from tools.policy_types import SandboxSpec, ToolPolicyExecutionContext
+from tools.policy_wrappers import PolicyWrappedTool
+from tools.registry import ToolManifestEntry
+
+
+def _manifest(name: str, *, sandbox: SandboxSpec | None = None) -> ToolManifestEntry:
+    return ToolManifestEntry(
+        name=name,
+        description="Returns a large fixture payload.",
+        args_schema=None,
+        response_format="content_and_artifact",
+        access_scope="inspection",
+        evidence_requirement="none",
+        output_contract_version="tool_result.v1",
+        source_module="tests.test_tool_output_overflow",
+        read_only=True,
+        destructive=False,
+        concurrency_safe=True,
+        planner_exposed=True,
+        verifier_exposed=True,
+        interrupt_behavior="restartable",
+        tool_validates_input=False,
+        activity_summary_hint="inspect",
+        result_summary_hint="result",
+        sandbox=sandbox,
+    )
+
+
+class _HugeTextTool(BaseTool):
+    """Returns a configurable multi-line fixture."""
+
+    name: str = "huge_text"
+    description: str = "Emits a large text blob."
+    response_format: str = "content_and_artifact"
+    line_count: int = 100_000
+
+    def _run(self) -> str:
+        # 100K distinct lines — easily past the default 16K-char cap.
+        return "\n".join(f"line-{index:06d}-payload" for index in range(self.line_count))
+
+    async def _arun(self) -> str:  # pragma: no cover - sync path is what we test
+        return self._run()
+
+
+def _wrap(tool: BaseTool, *, sandbox: SandboxSpec | None = None) -> PolicyWrappedTool:
+    return PolicyWrappedTool(
+        name=tool.name,
+        description=tool.description,
+        args_schema=None,
+        response_format="content_and_artifact",
+        wrapped_tool=tool,
+        manifest=_manifest(tool.name, sandbox=sandbox),
+    )
+
+
+@pytest.fixture
+def run_context() -> ToolPolicyExecutionContext:
+    return ToolPolicyExecutionContext(
+        session_id="sess-overflow",
+        request_id="req-overflow",
+        turn_id="turn-7",
+        allowed_access_scope="execution",
+    )
+
+
+def test_large_summary_spills_to_artifact_and_preserves_preview(
+    run_context, tmp_path, monkeypatch
+):
+    """100K-line fixture: summary truncates, artifact_refs carries the spill."""
+
+    monkeypatch.setenv("BIOAPEX_TOOL_OUTPUT_DIR", str(tmp_path / "tool-outputs"))
+
+    tool = _HugeTextTool()
+    expected_full_text = tool._run()
+    assert len(expected_full_text.encode("utf-8")) > MAX_STRUCTURED_PAYLOAD_JSON_CHARS, (
+        "fixture must exceed the default overflow threshold"
+    )
+
+    wrapper = _wrap(tool)
+    with tool_policy_context(run_context):
+        summary, artifact = wrapper._run()
+
+    # (a) Summary in the transcript is truncated.
+    assert "...[output truncated" in summary
+    assert len(summary.encode("utf-8")) <= MAX_STRUCTURED_PAYLOAD_JSON_CHARS + 128
+    assert "output_truncated" in artifact["warnings"]
+
+    # (b) Envelope carries exactly one tool_output_overflow artifact ref.
+    overflow_refs = [
+        ref
+        for ref in artifact["artifact_refs"]
+        if ref.get("artifact_type") == "tool_output_overflow"
+    ]
+    assert len(overflow_refs) == 1, artifact["artifact_refs"]
+    ref = overflow_refs[0]
+    assert ref["path"], "artifact ref must include a path"
+    assert ref["label"] == "huge_text full output"
+    assert artifact["metadata"]["tool_output_overflow"]["triggered"] is True
+    assert (
+        artifact["metadata"]["tool_output_overflow"]["summary_bytes_before_cap"]
+        == len(expected_full_text.encode("utf-8"))
+    )
+
+    # (c) The referenced file holds the full original text, not the preview.
+    spill_path = (tmp_path / "tool-outputs").rglob("*.txt")
+    spill_files = list(spill_path)
+    assert len(spill_files) == 1, spill_files
+    persisted = spill_files[0].read_text(encoding="utf-8")
+    assert persisted == expected_full_text
+    assert persisted.count("\n") == tool.line_count - 1
+
+
+def test_sandbox_cap_still_spills_full_output(run_context, tmp_path, monkeypatch):
+    """A tighter sandbox cap must not swallow the artifact spill behaviour."""
+
+    monkeypatch.setenv("BIOAPEX_TOOL_OUTPUT_DIR", str(tmp_path / "tool-outputs"))
+
+    tool = _HugeTextTool(line_count=500)
+    wrapper = _wrap(tool, sandbox=SandboxSpec(max_output_bytes=256))
+
+    expected_full_text = tool._run()
+    with tool_policy_context(run_context):
+        summary, artifact = wrapper._run()
+
+    # Sandbox cap fires — existing marker/warning/metadata preserved.
+    assert "[sandbox output truncated]" in summary
+    assert "sandbox_output_truncated" in artifact["warnings"]
+    assert artifact["metadata"]["sandbox"]["max_output_bytes"] == 256
+
+    # Plus the new overflow artifact is emitted with the untruncated text.
+    overflow_refs = [
+        ref
+        for ref in artifact["artifact_refs"]
+        if ref.get("artifact_type") == "tool_output_overflow"
+    ]
+    assert len(overflow_refs) == 1
+    persisted = Path((tmp_path / "tool-outputs")).rglob("*.txt")
+    spill_files = list(persisted)
+    assert len(spill_files) == 1
+    assert spill_files[0].read_text(encoding="utf-8") == expected_full_text
+
+
+def test_small_output_passes_through_unchanged(run_context, tmp_path, monkeypatch):
+    """Short outputs must not trigger the overflow artifact path."""
+
+    monkeypatch.setenv("BIOAPEX_TOOL_OUTPUT_DIR", str(tmp_path / "tool-outputs"))
+
+    tool = _HugeTextTool(line_count=5)
+    wrapper = _wrap(tool)
+
+    with tool_policy_context(run_context):
+        summary, artifact = wrapper._run()
+
+    assert "truncated" not in summary
+    assert not any(
+        ref.get("artifact_type") == "tool_output_overflow"
+        for ref in artifact["artifact_refs"]
+    )
+    assert not (tmp_path / "tool-outputs").exists() or not any(
+        (tmp_path / "tool-outputs").rglob("*.txt")
+    )

--- a/backend/tools/policy_wrappers.py
+++ b/backend/tools/policy_wrappers.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
+import re
 import threading
 import time
 from datetime import datetime, timezone
@@ -16,6 +18,8 @@ from pydantic import ConfigDict, Field
 from runtime import hooks as runtime_hooks
 
 from .contracts import (
+    MAX_STRUCTURED_PAYLOAD_JSON_CHARS,
+    ToolArtifactRef,
     ToolResultEnvelope,
     blocked_result,
     execution_error_result,
@@ -36,8 +40,18 @@ logger = logging.getLogger(__name__)
 
 _MAX_LOGGED_ARG_CHARS = 500
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-_DEFAULT_TRACE_DIR = Path(__file__).resolve().parents[1] / "storage" / "tool-traces"
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_TRACE_DIR = _BACKEND_ROOT / "storage" / "tool-traces"
 _TRACE_DIR_ENV = "BIOAPEX_TOOL_TRACE_DIR"
+_DEFAULT_TOOL_OUTPUT_DIR = _BACKEND_ROOT / "storage" / "tool-outputs"
+_TOOL_OUTPUT_DIR_ENV = "BIOAPEX_TOOL_OUTPUT_DIR"
+# Summaries over this byte budget are spilled to disk as a
+# ``tool_output_overflow`` artifact and replaced in the transcript with a
+# truncated preview. Matches the char cap the contract layer uses for
+# structured payloads so the preview in the transcript never grows past what
+# the prompt layer can consume in a single tool turn.
+_DEFAULT_SUMMARY_OVERFLOW_BYTES = MAX_STRUCTURED_PAYLOAD_JSON_CHARS
+_PATH_FRAGMENT_SAFE_RE = re.compile(r"[^A-Za-z0-9_.-]+")
 _SENSITIVE_KW_KEYS = frozenset({"token", "api_key", "password", "authorization"})
 _REDACTED_PATH_MARKER = "<redacted-path>"
 _REDACTED_VALUE_MARKER = "<redacted>"
@@ -81,6 +95,68 @@ def _resolve_trace_dir() -> Path:
     if override:
         return Path(override)
     return _DEFAULT_TRACE_DIR
+
+
+def _resolve_tool_output_dir() -> Path:
+    override = os.environ.get(_TOOL_OUTPUT_DIR_ENV)
+    if override:
+        return Path(override)
+    return _DEFAULT_TOOL_OUTPUT_DIR
+
+
+def _sanitize_path_fragment(value: str | None, *, default: str) -> str:
+    if not value:
+        return default
+    cleaned = _PATH_FRAGMENT_SAFE_RE.sub("_", str(value)).strip("._")
+    if not cleaned:
+        return default
+    return cleaned[:64]
+
+
+def _persist_tool_output_overflow(
+    *,
+    tool_name: str,
+    session_id: str | None,
+    turn_id: str | None,
+    full_text: str,
+) -> ToolArtifactRef | None:
+    """Write the oversized summary to disk and return a typed artifact ref.
+
+    Returns ``None`` on filesystem failure so the truncation path still
+    completes; the truncation marker in the transcript tells the caller the
+    full output is unavailable.
+    """
+
+    try:
+        encoded = full_text.encode("utf-8", errors="replace")
+        digest = hashlib.sha256(encoded).hexdigest()[:12]
+        target_root = _resolve_tool_output_dir()
+        session_segment = _sanitize_path_fragment(session_id, default="_no_session")
+        target_dir = target_root / session_segment
+        target_dir.mkdir(parents=True, exist_ok=True)
+        turn_segment = _sanitize_path_fragment(turn_id, default="_no_turn")
+        tool_segment = _sanitize_path_fragment(tool_name, default="tool")
+        filename = f"{turn_segment}-{tool_segment}-{digest}.txt"
+        path = target_dir / filename
+        path.write_bytes(encoded)
+        try:
+            stored = str(path.resolve().relative_to(_BACKEND_ROOT))
+        except ValueError:
+            stored = str(path)
+        return ToolArtifactRef(
+            path=stored,
+            label=f"{tool_name} full output",
+            artifact_type="tool_output_overflow",
+            identifier=f"{tool_segment}-{digest}",
+        )
+    except Exception:  # pragma: no cover - defensive
+        logger.warning(
+            "Failed to persist oversized tool output for %s (session=%s)",
+            tool_name,
+            session_id,
+            exc_info=True,
+        )
+        return None
 
 
 def _redact_path_if_external(value: str) -> str:
@@ -286,32 +362,97 @@ class PolicyWrappedTool(BaseTool):
             raise _SandboxWallClockExceeded(max_wall_clock) from exc
 
     def _apply_output_byte_cap(self, envelope: ToolResultEnvelope) -> ToolResultEnvelope:
-        sandbox = self.manifest.sandbox
-        if sandbox is None or sandbox.max_output_bytes is None:
-            return envelope
-        max_bytes = sandbox.max_output_bytes
-        if max_bytes <= 0:
-            return envelope
+        """Cap the envelope summary and spill the full text to an artifact.
+
+        The wrapper enforces two separate thresholds:
+
+        * ``sandbox.max_output_bytes`` — the per-tool policy cap. When this
+          fires we keep the legacy ``sandbox_output_truncated`` warning,
+          marker, and metadata so existing policy/observability assertions
+          stay green.
+        * ``_DEFAULT_SUMMARY_OVERFLOW_BYTES`` — a default overflow budget
+          applied to every tool, mirroring the contract-layer payload cap.
+          Preserves the transcript from ballooning when a tool happens to
+          not declare a sandbox.
+
+        Whichever threshold fires, the *original* summary is spilled to
+        ``backend/storage/tool-outputs/<session>/<turn>-<tool>-<hash>.txt``
+        and a ``tool_output_overflow`` ``ToolArtifactRef`` is appended so
+        the UI can surface a "full output →" link against the truncated
+        preview in the transcript.
+        """
+
         summary = envelope.summary or ""
-        encoded = summary.encode("utf-8")
-        if len(encoded) <= max_bytes:
+        if not summary:
             return envelope
-        truncated = encoded[:max_bytes].decode("utf-8", errors="ignore")
-        marker = "\n...[sandbox output truncated]"
+
+        encoded = summary.encode("utf-8")
+        sandbox = self.manifest.sandbox
+        sandbox_cap = (
+            sandbox.max_output_bytes
+            if sandbox is not None
+            and sandbox.max_output_bytes is not None
+            and sandbox.max_output_bytes > 0
+            else None
+        )
+        default_cap = _DEFAULT_SUMMARY_OVERFLOW_BYTES
+        candidate_caps = [cap for cap in (sandbox_cap, default_cap) if cap and cap > 0]
+        if not candidate_caps:
+            return envelope
+        effective_cap = min(candidate_caps)
+        if len(encoded) <= effective_cap:
+            return envelope
+
+        sandbox_triggered = sandbox_cap is not None and len(encoded) > sandbox_cap
+
+        policy_context = get_tool_policy_context()
+        artifact = _persist_tool_output_overflow(
+            tool_name=self.name,
+            session_id=policy_context.session_id if policy_context else None,
+            turn_id=policy_context.turn_id if policy_context else None,
+            full_text=summary,
+        )
+
+        truncated = encoded[:effective_cap].decode("utf-8", errors="ignore")
+        if sandbox_triggered:
+            marker = "\n...[sandbox output truncated]"
+        elif artifact is not None:
+            marker = "\n...[output truncated — full output saved as artifact]"
+        else:
+            marker = "\n...[output truncated]"
         envelope.summary = truncated + marker
-        if "sandbox_output_truncated" not in envelope.warnings:
+
+        if sandbox_triggered and "sandbox_output_truncated" not in envelope.warnings:
             envelope.warnings.append("sandbox_output_truncated")
+        if not sandbox_triggered and "output_truncated" not in envelope.warnings:
+            envelope.warnings.append("output_truncated")
+
         metadata = dict(envelope.metadata)
-        metadata.setdefault("sandbox", {})
-        if isinstance(metadata["sandbox"], dict):
-            metadata["sandbox"].update(
+        if sandbox_triggered:
+            sandbox_meta = metadata.get("sandbox")
+            if not isinstance(sandbox_meta, dict):
+                sandbox_meta = {}
+            sandbox_meta.update(
                 {
                     "output_truncated": True,
-                    "max_output_bytes": max_bytes,
+                    "max_output_bytes": sandbox_cap,
                     "summary_bytes_before_cap": len(encoded),
                 }
             )
+            metadata["sandbox"] = sandbox_meta
+        overflow_meta: dict[str, Any] = {
+            "triggered": True,
+            "threshold_bytes": effective_cap,
+            "summary_bytes_before_cap": len(encoded),
+            "sandbox_triggered": sandbox_triggered,
+        }
+        if artifact is not None and artifact.path:
+            overflow_meta["artifact_path"] = artifact.path
+        metadata["tool_output_overflow"] = overflow_meta
         envelope.metadata = metadata
+
+        if artifact is not None:
+            envelope.artifact_refs = [*envelope.artifact_refs, artifact]
         return envelope
 
     def _handle_tool_exception(

--- a/frontend/src/components/chat/blocks/FeedLine.tsx
+++ b/frontend/src/components/chat/blocks/FeedLine.tsx
@@ -7,6 +7,7 @@ import type { FeedLineDescriptor } from "./types";
 export default function FeedLine({
   text,
   tone = "default",
+  fullOutput,
 }: Omit<FeedLineDescriptor, "kind">) {
   return (
     <p
@@ -16,6 +17,19 @@ export default function FeedLine({
       )}
     >
       {text}
+      {fullOutput ? (
+        <>
+          {" "}
+          <a
+            href={fullOutput.href}
+            target="_blank"
+            rel="noreferrer"
+            className="not-italic font-medium text-[var(--apex-accent-strong)] underline decoration-dotted underline-offset-2 hover:decoration-solid"
+          >
+            {fullOutput.label ?? "full output →"}
+          </a>
+        </>
+      ) : null}
     </p>
   );
 }

--- a/frontend/src/components/chat/blocks/types.ts
+++ b/frontend/src/components/chat/blocks/types.ts
@@ -21,10 +21,16 @@ export interface FeedPlanningDescriptor {
   tone?: FeedTone;
 }
 
+export interface FeedLineFullOutputLink {
+  href: string;
+  label?: string;
+}
+
 export interface FeedLineDescriptor {
   kind: "line";
   text: string;
   tone?: FeedTone;
+  fullOutput?: FeedLineFullOutputLink;
 }
 
 export interface FeedGateDescriptor {

--- a/frontend/src/components/chat/turn-activity-feed.helpers.ts
+++ b/frontend/src/components/chat/turn-activity-feed.helpers.ts
@@ -1,3 +1,4 @@
+import { getRawFileUrl } from "@/lib/api";
 import { getEvidenceReviewPayload } from "@/lib/evidence";
 import { deriveMessageBlocks } from "@/lib/message-blocks";
 import type {
@@ -10,11 +11,36 @@ import type {
 import type {
   FeedEntryDescriptor,
   FeedLineDescriptor,
+  FeedLineFullOutputLink,
   FeedPlanningDescriptor,
   FeedSectionDescriptor,
   FeedSectionKey,
   FeedTone,
 } from "./blocks/types";
+
+const TOOL_OUTPUT_OVERFLOW_ARTIFACT_TYPE = "tool_output_overflow";
+
+function fullOutputLinkFromResult(
+  result?: ToolResultEnvelope
+): FeedLineFullOutputLink | undefined {
+  const refs = result?.artifact_refs;
+  if (!refs || refs.length === 0) {
+    return undefined;
+  }
+
+  const overflow = refs.find(
+    (ref) =>
+      ref.artifact_type === TOOL_OUTPUT_OVERFLOW_ARTIFACT_TYPE && Boolean(ref.path)
+  );
+  if (!overflow?.path) {
+    return undefined;
+  }
+
+  return {
+    href: getRawFileUrl(overflow.path),
+    label: "full output →",
+  };
+}
 
 function humanizeValue(value?: string | null): string {
   if (!value) return "unknown";
@@ -522,12 +548,14 @@ function completedToolLine(
     ? compactUserFacingInline(input)
     : null;
   const detail = compactUserFacingInline(output, 72);
+  const fullOutput = fullOutputLinkFromResult(result);
 
   if (tool === "evidence_review") {
     return {
       kind: "line",
       text: "Ran evidence review.",
       tone: outcomeTone(result),
+      ...(fullOutput ? { fullOutput } : {}),
     };
   }
 
@@ -536,6 +564,7 @@ function completedToolLine(
       kind: "line",
       text: "Ran verification.",
       tone: outcomeTone(result),
+      ...(fullOutput ? { fullOutput } : {}),
     };
   }
 
@@ -544,6 +573,7 @@ function completedToolLine(
       kind: "line",
       text: `${sentenceCase(toolPhrase(tool))} hit an error.`,
       tone: "error",
+      ...(fullOutput ? { fullOutput } : {}),
     };
   }
 
@@ -552,6 +582,7 @@ function completedToolLine(
       kind: "line",
       text: "Used memory.",
       tone: outcomeTone(result),
+      ...(fullOutput ? { fullOutput } : {}),
     };
   }
 
@@ -563,6 +594,7 @@ function completedToolLine(
         ? `Ran ${toolPhrase(tool)}: ${detail}`
         : `Ran ${toolPhrase(tool)}.`,
     tone: outcomeTone(result),
+    ...(fullOutput ? { fullOutput } : {}),
   };
 }
 


### PR DESCRIPTION
Closes #129

Opened by the personal automation loop. Draft until human-reviewed.