### PR TITLE
auto: #233 Re-emit prompt-cache drift warning beyond once-per-session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,9 @@ Before editing, read the piece of the system you are about to touch:
   The prefix is frozen per-session via `SessionManager.freeze_session_prefix`
   on the first turn and reused verbatim by sub-agents through
   `runtime.subagent.resolve_session_stable_prefix`. **Adding a tool, skill,
-  or workspace edit mid-session breaks the cache** (one-shot
-  `session_prefix_drift` warning). Per-run cache stats land on the subagent
+  or workspace edit mid-session breaks the cache** (a `session_prefix_drift`
+  warning fires on every drifting turn so repeated degradation stays
+  visible). Per-run cache stats land on the subagent
   artifact under `cache_stats`; aggregates land on the `bioapex_prompt_cache_*`
   Prometheus metrics.
 - Frontend state: `frontend/src/lib/store.tsx`, `api.ts`,

--- a/backend/graph/session/session_store.py
+++ b/backend/graph/session/session_store.py
@@ -97,7 +97,6 @@ class FrozenSessionPrefix:
 # Per-session frozen prefix cache. Sub-agent contracts read this to reuse the
 # byte-identical leading prompt and maximise prompt-cache hits.
 _frozen_prefixes: dict[str, FrozenSessionPrefix] = {}
-_frozen_prefix_drift_logged: set[str] = set()
 _frozen_prefix_lock = threading.Lock()
 
 
@@ -537,17 +536,17 @@ class SessionStore:
         The prefix + tool list are the leading bytes of the system prompt that
         must stay byte-identical across the parent turn and every sub-agent
         run for DeepSeek / OpenAI / Anthropic prompt-cache hits. We freeze on
-        the first turn and never replace the snapshot — subsequent turns with
-        a different prefix log a drift warning (workspace edits, skills added
-        mid-session) so the loss of cache-eligibility is visible.
+        the first turn and never replace the snapshot — every subsequent turn
+        whose prefix fingerprint no longer matches emits a drift warning
+        (workspace edits, skills added mid-session) so repeated degradation
+        stays visible instead of being suppressed after the first occurrence.
         """
         _validate_session_id(session_id)
         fingerprint = _fingerprint_prefix(stable_prefix, tool_names)
         with _frozen_prefix_lock:
             existing = _frozen_prefixes.get(session_id)
             if existing is not None:
-                if existing.prefix_fingerprint != fingerprint and session_id not in _frozen_prefix_drift_logged:
-                    _frozen_prefix_drift_logged.add(session_id)
+                if existing.prefix_fingerprint != fingerprint:
                     logger.warning(
                         "session_prefix_drift session_id=%s — frozen prefix no "
                         "longer matches current prompt assembly; sub-agent "
@@ -574,7 +573,6 @@ class SessionStore:
         """Drop the frozen prefix (used when the session is deleted)."""
         with _frozen_prefix_lock:
             _frozen_prefixes.pop(session_id, None)
-            _frozen_prefix_drift_logged.discard(session_id)
 
     def get_session_meta(self, session_id: str) -> dict:
         data = self._read(session_id)

--- a/backend/tests/test_session_frozen_prefix.py
+++ b/backend/tests/test_session_frozen_prefix.py
@@ -56,7 +56,7 @@ class TestFrozenSessionPrefix:
         )
         assert sm.get_frozen_session_prefix(session_id) is frozen_a
 
-    def test_drift_logs_warning_once(self, tmp_path, caplog):
+    def test_drift_logs_warning_every_time(self, tmp_path, caplog):
         from graph.session_manager import SessionManager
 
         session_id = _valid_session_id(2)
@@ -79,9 +79,18 @@ class TestFrozenSessionPrefix:
                 stable_prefix="stable-edited-again",
                 tool_names=("a",),
             )
+            # A call whose fingerprint matches the frozen snapshot must not log.
+            sm.freeze_session_prefix(
+                session_id,
+                stable_prefix="stable",
+                tool_names=("a",),
+            )
 
         drift_logs = [r for r in caplog.records if "session_prefix_drift" in r.message]
-        assert len(drift_logs) == 1, "Drift warning must log only once per session"
+        assert len(drift_logs) == 2, (
+            "Drift warning must fire on every drifting call so repeated "
+            "degradation stays visible; matching calls must not log."
+        )
 
     def test_delete_session_clears_frozen_prefix(self, tmp_path):
         from graph.session_manager import SessionManager


### PR DESCRIPTION
Closes #233

Opened by the personal automation loop. Draft until human-reviewed.