### PR TITLE
Clarify threading.Lock usage in memory_indexer rebuild coordination

### DIFF
--- a/backend/graph/memory_indexer.py
+++ b/backend/graph/memory_indexer.py
@@ -150,7 +150,15 @@ class MemoryIndexer:
         self._probe_cache: dict[tuple[str, str], list[str]] = {}
         # Background rebuild coordination. `_schedule_lock` guards the
         # `_rebuild_in_flight` flag so concurrent `_maybe_rebuild` callers
-        # coalesce to a single worker rather than queueing duplicates.
+        # coalesce to a single worker rather than queueing duplicates. The
+        # check-and-set in `_maybe_rebuild` and the clear in
+        # `_run_background_rebuild`'s `finally` both run under this lock, so
+        # the flag transition is atomic across all callers.
+        # NOTE: this is `threading.Lock`, not `asyncio.Lock`, because the
+        # rebuild worker is a `threading.Thread` daemon and `_maybe_rebuild`
+        # is a sync method invoked from both sync and async call sites. An
+        # `asyncio.Lock` would not serialize the thread worker against sync
+        # callers and would also be bound to a single event loop.
         # `_rebuild_thread` is retained so callers (tests, shutdown paths) can
         # join the worker when they need deterministic completion.
         self._schedule_lock = threading.Lock()


### PR DESCRIPTION
## Summary
Enhanced documentation for the rebuild coordination mechanism in `MemoryIndexer` to clarify why `threading.Lock` is used instead of `asyncio.Lock` for synchronizing the background rebuild worker.

## Changes
- Expanded the comment explaining the `_schedule_lock` synchronization mechanism to document:
  - How the check-and-set operation in `_maybe_rebuild` and the clear in `_run_background_rebuild`'s `finally` block work atomically under the lock
  - Why `threading.Lock` is required instead of `asyncio.Lock`:
    - The rebuild worker runs as a `threading.Thread` daemon
    - `_maybe_rebuild` is a synchronous method called from both sync and async contexts
    - `asyncio.Lock` would not properly serialize against thread workers and would be bound to a single event loop

## Implementation Details
This is a documentation-only change that clarifies the existing synchronization strategy. The lock ensures that concurrent calls to `_maybe_rebuild` coalesce into a single background worker thread rather than queueing duplicate rebuild operations.

https://claude.ai/code/session_01CUnbwTq7aLeHXu8d58vBFi