### PR TITLE
Add session-level access scope tracking and enforcement

### DIFF
--- a/backend/access_control.py
+++ b/backend/access_control.py
@@ -15,6 +15,22 @@ _FORWARDED_CLIENT_HEADERS = ("forwarded", "x-forwarded-for", "x-real-ip")
 AccessScope = Literal["inspection", "execution", "admin"]
 AccessGrantMode = Literal["loopback", "bearer"]
 
+# Tier ordering for access scopes. ``inspection`` is the lowest (read-only),
+# ``execution`` permits running tools and authoring, ``admin`` is the highest
+# (destructive / privileged ops). A session bound to scope ``X`` may only run
+# turns whose required scope is ``<= X``.
+_SCOPE_ORDER: dict[str, int] = {"inspection": 0, "execution": 1, "admin": 2}
+
+
+def scope_satisfies(actual: str | None, required: AccessScope) -> bool:
+    """Return True if *actual* meets or exceeds *required* in the scope tier.
+
+    An unknown or missing *actual* returns False so callers fail closed.
+    """
+    if actual not in _SCOPE_ORDER:
+        return False
+    return _SCOPE_ORDER[actual] >= _SCOPE_ORDER[required]
+
 
 def is_loopback_client(request: Request | None) -> bool:
     client = request.client if request is not None else None
@@ -113,4 +129,5 @@ __all__ = [
     "require_execution_access",
     "require_inspection_access",
     "require_route_access",
+    "scope_satisfies",
 ]

--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -44,7 +44,7 @@ proceed (on approve) or route around the tool (on deny).
 """
 from typing import Literal
 
-from access_control import require_execution_access
+from access_control import require_execution_access, scope_satisfies
 from audit.store import append_tool_approval_decision_event
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
@@ -133,6 +133,18 @@ async def chat(request: ChatRequest, http_request: Request = None):
     session_manager = agent_manager.session_manager
     if session_manager is None:
         raise HTTPException(status_code=503, detail="Agent runtime is not initialized.")
+
+    # Defence-in-depth: ``require_execution_access`` above proves the *current*
+    # request is execution-eligible. This second check proves the *session*
+    # itself was bound to a scope that permits execution — preventing scope
+    # confusion when a session is created in a lower tier (e.g. inspection)
+    # but a later request happens to present an execution-tier credential.
+    session_scope = session_manager.get_session_access_scope(request.session_id)
+    if not scope_satisfies(session_scope, "execution"):
+        raise HTTPException(
+            status_code=403,
+            detail="Session scope is insufficient to start a chat turn.",
+        )
 
     turn_lock = session_manager.get_or_create_turn_lock(request.session_id)
     # Non-blocking check-then-acquire. ``asyncio.Lock.acquire()`` completes

--- a/backend/api/sessions.py
+++ b/backend/api/sessions.py
@@ -92,7 +92,10 @@ def list_session_files_workspace_summary(session_id: str, request: Request = Non
 @router.post("/sessions", status_code=201)
 def create_session(request: Request = None):
     require_execution_access(request)
-    session_id = _sm().create_session()
+    # The route requires execution access, so the session is bound to the
+    # ``execution`` tier. Recording it on the session JSON lets ``/api/chat``
+    # cross-check session scope against per-turn requirements (issue #240).
+    session_id = _sm().create_session(access_scope="execution")
     return _sm().get_session_meta(session_id)
 
 

--- a/backend/graph/session/session_store.py
+++ b/backend/graph/session/session_store.py
@@ -293,12 +293,36 @@ class SessionStore:
     # Public API                                                           #
     # ------------------------------------------------------------------ #
 
-    def create_session(self) -> str:
+    # Default access scope for new sessions and for sessions written before
+    # ``access_scope`` was persisted on the JSON record. Sessions could only
+    # be created via execution-scope routes prior to this change, so legacy
+    # records are treated as execution-bound rather than rejected.
+    _DEFAULT_ACCESS_SCOPE = "execution"
+    _VALID_ACCESS_SCOPES = ("inspection", "execution", "admin")
+
+    def create_session(self, *, access_scope: str = _DEFAULT_ACCESS_SCOPE) -> str:
+        if access_scope not in self._VALID_ACCESS_SCOPES:
+            raise ValueError(f"Invalid access_scope: {access_scope!r}")
         session_id = str(uuid.uuid4())
         data = self._empty(session_id)
+        data["access_scope"] = access_scope
         with self._locked(session_id):
             self._write(session_id, data)
         return session_id
+
+    def get_session_access_scope(self, session_id: str) -> str:
+        """Return the access scope bound to *session_id*.
+
+        Sessions written before ``access_scope`` was tracked silently default
+        to ``execution`` — they could only have been created through
+        execution-scope routes, so promoting them to that tier preserves the
+        prior contract without rejecting in-flight clients on upgrade.
+        """
+        data = self._read(session_id)
+        scope = data.get("access_scope")
+        if scope in self._VALID_ACCESS_SCOPES:
+            return scope
+        return self._DEFAULT_ACCESS_SCOPE
 
     def list_sessions(self) -> list[dict]:
         # Reads the ``_index.json`` sidecar so we avoid an O(N) glob+open of
@@ -578,12 +602,16 @@ class SessionStore:
 
     def get_session_meta(self, session_id: str) -> dict:
         data = self._read(session_id)
+        scope = data.get("access_scope")
+        if scope not in self._VALID_ACCESS_SCOPES:
+            scope = self._DEFAULT_ACCESS_SCOPE
         meta = {
             "id": session_id,
             "title": data.get("title", ""),
             "created_at": data.get("created_at", 0.0),
             "updated_at": data.get("updated_at", 0.0),
             "message_count": len(data.get("messages", [])),
+            "access_scope": scope,
         }
         runtime_config = data.get("runtime_config")
         if isinstance(runtime_config, dict):

--- a/backend/tests/test_chat_streaming.py
+++ b/backend/tests/test_chat_streaming.py
@@ -1027,6 +1027,25 @@ async def test_chat_blocks_non_local_clients_without_bearer_token(isolated_chat_
 
 
 @pytest.mark.asyncio
+async def test_chat_rejects_session_bound_below_execution_scope(isolated_chat_state):
+    """A session created at ``inspection`` scope must not run chat turns even
+    if the calling request itself meets the execution route check (issue #240)."""
+    from api.chat import ChatRequest, chat
+    from graph.agent import agent_manager
+
+    session_id = agent_manager.session_manager.create_session(access_scope="inspection")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await chat(
+            ChatRequest(message="Read memory", session_id=session_id),
+            _request("/api/chat"),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "scope" in str(exc_info.value.detail).lower()
+
+
+@pytest.mark.asyncio
 async def test_chat_allows_non_local_clients_with_execution_bearer_token(isolated_chat_state):
     from api.chat import ChatRequest, chat
     from graph.agent import agent_manager

--- a/backend/tests/test_hardening_smoke.py
+++ b/backend/tests/test_hardening_smoke.py
@@ -160,3 +160,27 @@ def test_trusted_lab_posture_rejects_unauthenticated_loopback_request(tmp_path):
         response = client.get("/api/access/probe", params={"scope": "execution"})
 
     assert response.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "actual,required,expected",
+    [
+        ("inspection", "inspection", True),
+        ("execution", "inspection", True),
+        ("admin", "inspection", True),
+        ("inspection", "execution", False),
+        ("execution", "execution", True),
+        ("admin", "execution", True),
+        ("inspection", "admin", False),
+        ("execution", "admin", False),
+        ("admin", "admin", True),
+        (None, "execution", False),
+        ("garbage", "execution", False),
+    ],
+)
+def test_scope_satisfies_orders_inspection_below_execution_below_admin(
+    actual, required, expected
+):
+    from access_control import scope_satisfies
+
+    assert scope_satisfies(actual, required) is expected

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -215,9 +215,36 @@ class TestCreateAndRead:
     def test_session_meta_fields(self, sm):
         sid = sm.create_session()
         meta = sm.get_session_meta(sid)
-        assert set(meta.keys()) == {"id", "title", "created_at", "updated_at", "message_count"}
+        assert set(meta.keys()) == {
+            "id",
+            "title",
+            "created_at",
+            "updated_at",
+            "message_count",
+            "access_scope",
+        }
         assert meta["id"] == sid
         assert meta["message_count"] == 0
+        assert meta["access_scope"] == "execution"
+
+    def test_create_session_persists_access_scope(self, sm, tmp_path):
+        sid = sm.create_session(access_scope="admin")
+        raw = json.loads((tmp_path / "sessions" / f"{sid}.json").read_text())
+        assert raw["access_scope"] == "admin"
+        assert sm.get_session_access_scope(sid) == "admin"
+
+    def test_create_session_rejects_unknown_scope(self, sm):
+        with pytest.raises(ValueError):
+            sm.create_session(access_scope="superuser")
+
+    def test_legacy_session_without_scope_defaults_to_execution(self, sm, tmp_path):
+        sid = sm.create_session()
+        path = tmp_path / "sessions" / f"{sid}.json"
+        raw = json.loads(path.read_text())
+        raw.pop("access_scope", None)
+        path.write_text(json.dumps(raw))
+        assert sm.get_session_access_scope(sid) == "execution"
+        assert sm.get_session_meta(sid)["access_scope"] == "execution"
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Implements session-level access scope tracking to enforce a defense-in-depth security model where sessions are bound to specific access tiers (inspection, execution, admin) at creation time. This prevents scope confusion attacks where a lower-tier session could be exploited if a higher-tier credential is presented in a later request.

## Key Changes

- **Access scope persistence**: Sessions now store an `access_scope` field indicating the tier at which they were created (inspection, execution, or admin)
  - `create_session()` accepts an optional `access_scope` parameter (defaults to "execution")
  - Validates scope against allowed values: "inspection", "execution", "admin"
  - Legacy sessions without the field default to "execution" for backward compatibility

- **Scope hierarchy and validation**: Introduced `scope_satisfies()` utility function that enforces a tier ordering:
  - `inspection` (tier 0): read-only access
  - `execution` (tier 1): tool execution and authoring
  - `admin` (tier 2): destructive/privileged operations
  - A session at scope X can only run turns requiring scope ≤ X

- **Session metadata enrichment**: `get_session_meta()` now includes the `access_scope` field in returned metadata

- **Chat endpoint hardening**: `/api/chat` now performs a second access check:
  - First check: validates the current request has execution access
  - Second check: validates the session itself was bound to execution scope or higher
  - Prevents execution of chat turns on inspection-scoped sessions even if the request presents an execution credential

- **Session creation route**: `/sessions` POST endpoint explicitly creates sessions at "execution" scope, matching the route's access requirement

## Implementation Details

- Scope validation uses a closed-set approach (fail-closed for unknown scopes)
- Legacy session handling preserves backward compatibility by defaulting to "execution" tier
- The scope hierarchy is defined in `access_control.py` for centralized access control logic
- Comprehensive test coverage including legacy session migration and scope validation

https://claude.ai/code/session_011k33wGSM2tAWNbgZ18zM3G