### PR TITLE
Add argument-scoped approval gating and prompt-cache invalidation signals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,9 @@ Before editing, read the piece of the system you are about to touch:
   The prefix is frozen per-session via `SessionManager.freeze_session_prefix`
   on the first turn and reused verbatim by sub-agents through
   `runtime.subagent.resolve_session_stable_prefix`. **Adding a tool, skill,
-  or workspace edit mid-session breaks the cache** (one-shot
-  `session_prefix_drift` warning). Per-run cache stats land on the subagent
+  or workspace edit mid-session breaks the cache** (a `session_prefix_drift`
+  warning fires on every drifting turn so repeated degradation stays
+  visible). Per-run cache stats land on the subagent
   artifact under `cache_stats`; aggregates land on the `bioapex_prompt_cache_*`
   Prometheus metrics.
 - Frontend state: `frontend/src/lib/store.tsx`, `api.ts`,

--- a/README.md
+++ b/README.md
@@ -298,13 +298,15 @@ normalized `AIMessage.usage_metadata` (`input_token_details.cache_read` and
   per-run `cache_hit_rate`.
 
 **Adding a tool, skill, or workspace edit mid-session breaks the cache.**
-The frozen prefix is sticky for the lifetime of the session; if the prompt
-assembly changes after the first turn (a skill is enabled, a workspace file
-is edited, the runtime is reconfigured) the new prefix no longer matches the
-frozen one and provider prefix caching falls through. The runtime logs a
-single `session_prefix_drift` warning the first time it sees a divergent
-prefix for a given session id so the loss of cache eligibility is visible.
-To recover the cache hit rate, start a new chat session.
+The stable prefix is re-fingerprinted every turn. When a prompt-assembly
+input changes after the first turn (a skill is enabled, a workspace file is
+edited, the runtime is reconfigured) the runtime drops the stale snapshot,
+installs the fresh prefix, emits a `session_prefix_invalidated` log line,
+and streams a `prefix_invalidated` SSE event so the UI can surface that the
+provider-side cache was invalidated. Sub-agents launched on subsequent turns
+read the fresh prefix via `resolve_session_stable_prefix`. The current turn
+pays a full cache-creation cost; following turns rehydrate against the new
+prefix.
 
 ### Tools
 

--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -15,6 +15,7 @@ SSE event types emitted:
   plan_updated {type, summary, plan, tool_trace?, run_id?}
   verification_result {type, summary, verdict, verification, tool_trace?, run_id?}
   new_response {type}
+  prefix_invalidated {type, session_id?, previous_fingerprint?, current_fingerprint?, reason?}
   done         {type, content, session_id, turn_status?, exit}
   error        {type, error}
   warning      {type, kind, message, ...}

--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -82,6 +82,11 @@ class ApprovalDecisionRequest(BaseModel):
     decision: Literal["approve", "deny"]
     actor: str = Field(default="ui-user")
     rationale: str | None = None
+    # Stable SHA-256 digest of the tool's canonical-JSON kwargs computed by
+    # the frontend (or the policy wrapper, surfaced on the gate event). An
+    # approval is bound to this exact args_hash; the next call to the same
+    # tool with different arguments re-prompts the reviewer.
+    args_hash: str = Field(default="")
 
     @field_validator("actor")
     @classmethod
@@ -204,6 +209,7 @@ async def submit_approval_decision(
         decision=request.decision,
         actor=request.actor,
         rationale=request.rationale,
+        args_hash=request.args_hash,
     )
 
     append_tool_approval_decision_event(

--- a/backend/api/files.py
+++ b/backend/api/files.py
@@ -159,10 +159,18 @@ def _check_path(relative_path: str, *, write: bool = False) -> tuple[Path, str]:
 
 
 def _guess_media_type(path: Path) -> str:
+    suffix = path.suffix.lower()
+    # Force an explicit charset for plain-text so tool-output overflow spills
+    # (written as ``.txt`` under ``storage/tool-outputs/`` by
+    # ``tools.policy_wrappers._persist_tool_output_overflow``) cannot be
+    # MIME-sniffed into HTML if they happen to contain ``<script>``. Paired
+    # with the ``X-Content-Type-Options: nosniff`` header on the serving
+    # endpoints below.
+    if suffix == ".txt":
+        return "text/plain; charset=utf-8"
     guessed, _ = mimetypes.guess_type(path.name)
     if guessed:
         return guessed
-    suffix = path.suffix.lower()
     if suffix == ".json":
         return "application/json"
     if suffix in {".yaml", ".yml"}:
@@ -170,6 +178,11 @@ def _guess_media_type(path: Path) -> str:
     if suffix == ".md":
         return "text/markdown"
     return "text/plain; charset=utf-8"
+
+
+# Defense-in-depth: ``nosniff`` prevents browsers from overriding the
+# ``Content-Type`` we declare above when serving whitelisted files.
+_NOSNIFF_HEADER = {"X-Content-Type-Options": "nosniff"}
 
 
 def _read_raw_content(target: Path, clean_path: str) -> str:
@@ -223,9 +236,14 @@ def read_raw_file(path: str = Query(..., description="Relative file path"), requ
         return Response(
             content=_read_raw_content(target, clean).encode("utf-8"),
             media_type=media_type,
+            headers=_NOSNIFF_HEADER,
         )
 
-    return Response(content=target.read_bytes(), media_type=media_type)
+    return Response(
+        content=target.read_bytes(),
+        media_type=media_type,
+        headers=_NOSNIFF_HEADER,
+    )
 
 
 # ------------------------------------------------------------------ #
@@ -326,6 +344,7 @@ def head_stream_file(
         "ETag": _etag_for(stat),
         "Last-Modified": formatdate(stat.st_mtime, usegmt=True),
         "Content-Length": str(stat.st_size),
+        **_NOSNIFF_HEADER,
     }
     return Response(status_code=200, media_type=_guess_media_type(target), headers=headers)
 
@@ -383,6 +402,7 @@ def stream_file(
         "ETag": etag,
         "Last-Modified": last_modified,
         "Content-Length": str(length),
+        **_NOSNIFF_HEADER,
     }
     if is_partial:
         headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"

--- a/backend/artifacts/provenance.py
+++ b/backend/artifacts/provenance.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import os
 from datetime import datetime, timezone
@@ -23,6 +25,60 @@ _RO_CRATE_CONTEXT_URL = "https://w3id.org/ro/crate/1.2/context"
 _RO_CRATE_SPEC_URL = "https://w3id.org/ro/crate/1.2"
 _PROV_SPEC_URL = "https://www.w3.org/TR/prov-overview/"
 _RO_CRATE_METADATA_FILENAME = "ro-crate-metadata.json"
+
+SIGNATURE_ALGORITHM = "HMAC-SHA256"
+_SIGNATURE_FIELD = "signature"
+_HMAC_KEY_ENV = "BIOAPEX_PROVENANCE_HMAC_KEY"
+
+
+class ProvenanceSignatureError(Exception):
+    """Raised when a provenance bundle cannot be signed or verified."""
+
+
+def _load_hmac_key() -> bytes:
+    key = os.environ.get(_HMAC_KEY_ENV)
+    if not key:
+        raise ProvenanceSignatureError(
+            f"Provenance HMAC key is not configured ({_HMAC_KEY_ENV} unset)."
+        )
+    return key.encode("utf-8")
+
+
+def _canonical_payload_bytes(payload: dict[str, Any]) -> bytes:
+    without_signature = {k: v for k, v in payload.items() if k != _SIGNATURE_FIELD}
+    return json.dumps(
+        without_signature,
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def sign_provenance_payload(payload: dict[str, Any]) -> dict[str, str]:
+    """Embed an HMAC-SHA256 signature block into *payload* and return it."""
+    key = _load_hmac_key()
+    digest = hmac.new(key, _canonical_payload_bytes(payload), hashlib.sha256).hexdigest()
+    signature = {"algorithm": SIGNATURE_ALGORITHM, "digest": digest}
+    payload[_SIGNATURE_FIELD] = signature
+    return signature
+
+
+def verify_provenance_bundle(path: Path | str) -> dict[str, Any]:
+    """Load a provenance bundle from *path* and verify its HMAC signature."""
+    bundle_path = Path(path)
+    payload = json.loads(bundle_path.read_text(encoding="utf-8"))
+    signature = payload.get(_SIGNATURE_FIELD)
+    if not isinstance(signature, dict) or not isinstance(signature.get("digest"), str):
+        raise ProvenanceSignatureError(
+            f"Provenance bundle at {bundle_path} is missing a signature."
+        )
+    key = _load_hmac_key()
+    expected = hmac.new(key, _canonical_payload_bytes(payload), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, signature["digest"]):
+        raise ProvenanceSignatureError(
+            f"Provenance bundle at {bundle_path} has a signature mismatch."
+        )
+    return payload
 
 
 def _utcnow() -> datetime:
@@ -241,6 +297,8 @@ def materialize_provenance_bundle(
         "prov": _PROV_SPEC_URL,
     }
 
+    provenance_signature = sign_provenance_payload(provenance_payload)
+
     provenance_target = layout._track_path(resolve_artifact_path(layout.run_dir, provenance_relpath))
     provenance_target.write_text(json.dumps(provenance_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
@@ -257,6 +315,7 @@ def materialize_provenance_bundle(
         step_agent_ids=step_agent_ids,
         workflow_activity_id=workflow_activity_id,
         activities=activities,
+        provenance_signature=provenance_signature,
     )
     ro_crate_target.write_text(json.dumps(ro_crate_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     append_export_generated_event(
@@ -546,6 +605,7 @@ def _build_ro_crate_payload(
     step_agent_ids: dict[str, set[str]],
     workflow_activity_id: str,
     activities: dict[str, dict[str, Any]],
+    provenance_signature: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     ro_crate_dir = layout.run_dir / stable_artifact_name("ro_crate")
     graph: list[dict[str, Any]] = [
@@ -603,16 +663,18 @@ def _build_ro_crate_payload(
     prov_id = "../prov.json"
     prov_path = layout.run_dir / stable_artifact_name("provenance")
     if prov_path.exists() and prov_path.is_file():
-        graph.append(
-            {
-                "@id": prov_id,
-                "@type": "File",
-                "name": prov_path.name,
-                "encodingFormat": "application/json",
-                "sha256": compute_content_hash(prov_path.read_bytes()),
-                "description": "PROV-compatible lineage export for this workflow run.",
-            }
-        )
+        prov_entry: dict[str, Any] = {
+            "@id": prov_id,
+            "@type": "File",
+            "name": prov_path.name,
+            "encodingFormat": "application/json",
+            "sha256": compute_content_hash(prov_path.read_bytes()),
+            "description": "PROV-compatible lineage export for this workflow run.",
+        }
+        if provenance_signature is not None:
+            prov_entry["signatureAlgorithm"] = provenance_signature["algorithm"]
+            prov_entry["signatureDigest"] = provenance_signature["digest"]
+        graph.append(prov_entry)
         has_part.append({"@id": prov_id})
 
     workflow_activity = activities[workflow_activity_id]

--- a/backend/graph/agent.py
+++ b/backend/graph/agent.py
@@ -169,10 +169,17 @@ class AgentManager:
         has changed since the last build for this session.
 
         The stable prefix half of the prompt (workspace files, skill snapshot,
-        tool-result contract, harness guidance) is frozen on the session on
-        first call so sub-agent runs can reuse it for provider prompt-cache
-        hits. The volatile suffix (memory index, git context) is appended
-        fresh each turn and is intentionally excluded from the frozen prefix.
+        tool-result contract, harness guidance) is re-fingerprinted every turn
+        so workspace/skills edits mid-session drop the stale frozen snapshot
+        and install the fresh prefix sub-agents will see. The volatile suffix
+        (memory index, git context) is appended fresh each turn and is
+        intentionally excluded from the frozen prefix.
+
+        Returns ``(agent, registration)``. ``registration`` is the
+        :class:`FrozenPrefixRegistration` returned by the session manager on
+        this turn when ``session_id`` was supplied, otherwise ``None``.
+        Callers use ``registration.invalidated`` to surface a
+        ``prefix_invalidated`` SSE event to the UI.
         """
         assert self.base_dir is not None, "AgentManager not initialised"
         stable_prefix, volatile_suffix = build_system_prompt_blocks(
@@ -186,8 +193,9 @@ class AgentManager:
         tool_names = tuple(
             getattr(tool, "name", type(tool).__name__) for tool in self.tools
         )
+        prefix_registration = None
         if session_id and self.session_manager is not None:
-            self.session_manager.freeze_session_prefix(
+            prefix_registration = self.session_manager.freeze_session_prefix(
                 session_id,
                 stable_prefix=stable_prefix_with_harness,
                 tool_names=tool_names,
@@ -207,7 +215,7 @@ class AgentManager:
             async with self._cache_lock:
                 cached = self._agent_cache.get(key)
                 if cached is not None:
-                    return cached
+                    return cached, prefix_registration
                 agent = create_agent(
                     effective_llm, self.tools, system_prompt=system_prompt
                 )
@@ -220,9 +228,12 @@ class AgentManager:
                 for stale in stale_keys:
                     self._agent_cache.pop(stale, None)
                 self._agent_cache[key] = agent
-                return agent
+                return agent, prefix_registration
 
-        return create_agent(effective_llm, self.tools, system_prompt=system_prompt)
+        return (
+            create_agent(effective_llm, self.tools, system_prompt=system_prompt),
+            prefix_registration,
+        )
 
     async def _run_llm_probe_retrieval(
         self,
@@ -404,7 +415,7 @@ class AgentManager:
         set_active_skills_on_current_context(selected_skill_entries)
         policy_context = get_tool_policy_context()
         session_id = policy_context.session_id if policy_context is not None else None
-        agent = await self._build_agent(
+        agent, prefix_registration = await self._build_agent(
             rag_mode,
             skill_entries=selected_skill_entries,
             session_id=session_id,
@@ -416,6 +427,16 @@ class AgentManager:
         turn_started_at = datetime.now(timezone.utc)
         streamed_any_event = False
         used_fallback = False
+
+        if prefix_registration is not None and prefix_registration.invalidated:
+            streamed_any_event = True
+            yield {
+                "type": "prefix_invalidated",
+                "session_id": session_id,
+                "previous_fingerprint": prefix_registration.previous_fingerprint,
+                "current_fingerprint": prefix_registration.frozen.prefix_fingerprint,
+                "reason": "workspace_or_skills_edit",
+            }
 
         # Biology requests with retrieval and multi-step reasoning often need
         # far more graph turns than LangGraph's small default budget.
@@ -554,7 +575,7 @@ class AgentManager:
                             role="executor",
                             exc=exc,
                         )
-                        agent = await self._build_agent(
+                        agent, _ = await self._build_agent(
                             rag_mode,
                             skill_entries=selected_skill_entries,
                             llm=fallback_llm,

--- a/backend/graph/approval_store.py
+++ b/backend/graph/approval_store.py
@@ -6,20 +6,24 @@ File-first, no database: each session's pending approval decisions live at
 for a turn; once a decision is consumed (turn completes) it is cleared so the
 next gated call re-prompts the reviewer.
 
-Decisions are keyed by tool name. Argument-fingerprint-scoped approvals are
-intentionally out of scope for the MVP — the gate pauses the turn right before
-the agent would re-invoke the same tool with the same arguments, so the next
-turn only needs to know "the reviewer said yes/no to this tool, this turn."
+Decisions are keyed by ``(session_id, tool_name, args_hash)`` with a short TTL
+(``APPROVAL_TTL_SECONDS``). An approval recorded for one set of tool arguments
+no longer applies to a later call with different arguments — the policy layer
+computes the args hash at gate-evaluation time and matches against the stored
+record. Expired records are dropped on load. Records for destructive
+manifests are stored but intentionally ignored at lookup time so destructive
+tools always re-prompt (see ``tools.policy._user_has_approved``).
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 logger = logging.getLogger(__name__)
 
@@ -27,18 +31,65 @@ ApprovalDecision = Literal["approve", "deny"]
 
 _STORE_SUBDIR = "storage/approvals"
 
+# How long a recorded approval/deny remains valid. After this window the
+# record is dropped on load and the reviewer must decide again. Short enough
+# that an abandoned approval cannot be silently reused by a later turn.
+APPROVAL_TTL_SECONDS = 300
+
 
 class ApprovalRecord(TypedDict):
     tool_name: str
     run_id: str
+    args_hash: str
     decision: ApprovalDecision
     actor: str
     rationale: str | None
     recorded_at: str
 
 
+def compute_args_hash(kwargs: dict[str, Any] | None) -> str:
+    """Return a stable SHA-256 digest over the tool's canonical-JSON kwargs.
+
+    Uses ``sort_keys=True`` and ``default=str`` so non-JSON-native values
+    (paths, datetimes, etc.) still produce a stable digest. ``None`` and an
+    empty dict both hash to the canonical empty-dict digest so callers that
+    have no kwargs still get a deterministic value to match against.
+    """
+    payload = kwargs or {}
+    try:
+        canonical = json.dumps(payload, sort_keys=True, ensure_ascii=False, default=str)
+    except Exception:
+        # Defensive fallback: a weird unserializable arg should still produce
+        # a digest rather than raise through the policy layer.
+        canonical = repr(sorted(payload.items())) if isinstance(payload, dict) else repr(payload)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
 def _store_path(base_dir: Path, session_id: str) -> Path:
     return Path(base_dir) / _STORE_SUBDIR / f"{session_id}.json"
+
+
+def _parse_recorded_at(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    candidate = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _is_expired(record: ApprovalRecord, *, now: datetime | None = None) -> bool:
+    recorded_at = _parse_recorded_at(record.get("recorded_at"))
+    if recorded_at is None:
+        # Unparseable timestamps are treated as expired — safer to re-prompt
+        # than to honor an ambiguous record.
+        return True
+    reference = now or datetime.now(timezone.utc)
+    return (reference - recorded_at) > timedelta(seconds=APPROVAL_TTL_SECONDS)
 
 
 def _load(base_dir: Path, session_id: str) -> list[ApprovalRecord]:
@@ -52,6 +103,7 @@ def _load(base_dir: Path, session_id: str) -> list[ApprovalRecord]:
         return []
     if not isinstance(raw, list):
         return []
+    now = datetime.now(timezone.utc)
     records: list[ApprovalRecord] = []
     for item in raw:
         if not isinstance(item, dict):
@@ -63,18 +115,23 @@ def _load(base_dir: Path, session_id: str) -> list[ApprovalRecord]:
             continue
         if decision not in {"approve", "deny"}:
             continue
-        records.append(
-            {
-                "tool_name": tool_name,
-                "run_id": run_id,
-                "decision": decision,
-                "actor": str(item.get("actor") or "ui-user"),
-                "rationale": (
-                    str(item["rationale"]) if isinstance(item.get("rationale"), str) else None
-                ),
-                "recorded_at": str(item.get("recorded_at") or _now_iso()),
-            }
-        )
+        args_hash = item.get("args_hash")
+        if not isinstance(args_hash, str):
+            args_hash = ""
+        record: ApprovalRecord = {
+            "tool_name": tool_name,
+            "run_id": run_id,
+            "args_hash": args_hash,
+            "decision": decision,
+            "actor": str(item.get("actor") or "ui-user"),
+            "rationale": (
+                str(item["rationale"]) if isinstance(item.get("rationale"), str) else None
+            ),
+            "recorded_at": str(item.get("recorded_at") or _now_iso()),
+        }
+        if _is_expired(record, now=now):
+            continue
+        records.append(record)
     return records
 
 
@@ -113,10 +170,12 @@ def record_decision(
     decision: ApprovalDecision,
     actor: str,
     rationale: str | None,
+    args_hash: str = "",
 ) -> ApprovalRecord:
     record: ApprovalRecord = {
         "tool_name": tool_name,
         "run_id": run_id,
+        "args_hash": args_hash,
         "decision": decision,
         "actor": actor,
         "rationale": rationale,
@@ -124,11 +183,15 @@ def record_decision(
     }
     records = _load(base_dir, session_id)
     # A reviewer may retry an approval decision after a typo — the latest
-    # decision for a (tool_name, run_id) tuple wins.
+    # decision for a (tool_name, run_id, args_hash) tuple wins.
     records = [
         item
         for item in records
-        if not (item["tool_name"] == tool_name and item["run_id"] == run_id)
+        if not (
+            item["tool_name"] == tool_name
+            and item["run_id"] == run_id
+            and item.get("args_hash", "") == args_hash
+        )
     ]
     records.append(record)
     _save(base_dir, session_id, records)
@@ -139,11 +202,24 @@ def pending_records(base_dir: Path, session_id: str) -> list[ApprovalRecord]:
     return list(_load(base_dir, session_id))
 
 
-def approved_tool_names(base_dir: Path, session_id: str) -> frozenset[str]:
+def approved_tool_runs(base_dir: Path, session_id: str) -> frozenset[tuple[str, str]]:
+    """Return ``(tool_name, args_hash)`` tuples the reviewer approved.
+
+    The policy layer is responsible for filtering destructive manifests out
+    of the matched set — that rule lives next to the manifest, not here.
+    """
     return frozenset(
-        record["tool_name"]
+        (record["tool_name"], record.get("args_hash", ""))
         for record in _load(base_dir, session_id)
         if record["decision"] == "approve"
+    )
+
+
+def denied_tool_runs(base_dir: Path, session_id: str) -> frozenset[tuple[str, str]]:
+    return frozenset(
+        (record["tool_name"], record.get("args_hash", ""))
+        for record in _load(base_dir, session_id)
+        if record["decision"] == "deny"
     )
 
 
@@ -175,11 +251,14 @@ def consume(base_dir: Path, session_id: str) -> list[ApprovalRecord]:
 
 
 __all__ = [
+    "APPROVAL_TTL_SECONDS",
     "ApprovalDecision",
     "ApprovalRecord",
-    "approved_tool_names",
+    "approved_tool_runs",
+    "compute_args_hash",
     "consume",
     "denied_records",
+    "denied_tool_runs",
     "pending_records",
     "record_decision",
 ]

--- a/backend/graph/approval_store.py
+++ b/backend/graph/approval_store.py
@@ -28,6 +28,15 @@ ApprovalDecision = Literal["approve", "deny"]
 _STORE_SUBDIR = "storage/approvals"
 
 
+class ApprovalStoreLoadError(RuntimeError):
+    """Raised when the on-disk approval store cannot be read or parsed.
+
+    Used by the strict loader so the runtime can fail closed for destructive
+    tools instead of silently degrading to "no approvals" when the JSON
+    file is corrupt or unreadable.
+    """
+
+
 class ApprovalRecord(TypedDict):
     tool_name: str
     run_id: str
@@ -41,15 +50,7 @@ def _store_path(base_dir: Path, session_id: str) -> Path:
     return Path(base_dir) / _STORE_SUBDIR / f"{session_id}.json"
 
 
-def _load(base_dir: Path, session_id: str) -> list[ApprovalRecord]:
-    path = _store_path(base_dir, session_id)
-    if not path.exists():
-        return []
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        logger.warning("Approval store for session %s is unreadable; ignoring.", session_id, exc_info=True)
-        return []
+def _parse_records(raw: object) -> list[ApprovalRecord]:
     if not isinstance(raw, list):
         return []
     records: list[ApprovalRecord] = []
@@ -76,6 +77,36 @@ def _load(base_dir: Path, session_id: str) -> list[ApprovalRecord]:
             }
         )
     return records
+
+
+def _load_strict(base_dir: Path, session_id: str) -> list[ApprovalRecord]:
+    """Load approval records, raising ``ApprovalStoreLoadError`` on failure.
+
+    A missing file is not a failure — the store is intentionally absent
+    between gated calls — but an unreadable or malformed JSON payload is.
+    """
+    path = _store_path(base_dir, session_id)
+    if not path.exists():
+        return []
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ApprovalStoreLoadError(
+            f"Approval store for session {session_id} is unreadable."
+        ) from exc
+    return _parse_records(raw)
+
+
+def _load(base_dir: Path, session_id: str) -> list[ApprovalRecord]:
+    path = _store_path(base_dir, session_id)
+    if not path.exists():
+        return []
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.warning("Approval store for session %s is unreadable; ignoring.", session_id, exc_info=True)
+        return []
+    return _parse_records(raw)
 
 
 def _save(base_dir: Path, session_id: str, records: list[ApprovalRecord]) -> None:
@@ -151,6 +182,26 @@ def denied_records(base_dir: Path, session_id: str) -> list[ApprovalRecord]:
     return [record for record in _load(base_dir, session_id) if record["decision"] == "deny"]
 
 
+def load_decisions_strict(
+    base_dir: Path, session_id: str
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Return ``(approved_tool_names, denied_tool_names)``, raising on failure.
+
+    Callers that need to fail closed when the on-disk store is corrupt
+    should use this helper instead of :func:`approved_tool_names` and
+    :func:`denied_records`, which swallow load errors and silently report
+    "no approvals".
+    """
+    records = _load_strict(base_dir, session_id)
+    approved = frozenset(
+        record["tool_name"] for record in records if record["decision"] == "approve"
+    )
+    denied = frozenset(
+        record["tool_name"] for record in records if record["decision"] == "deny"
+    )
+    return approved, denied
+
+
 def consume(base_dir: Path, session_id: str) -> list[ApprovalRecord]:
     """Return and clear pending decisions.
 
@@ -177,9 +228,11 @@ def consume(base_dir: Path, session_id: str) -> list[ApprovalRecord]:
 __all__ = [
     "ApprovalDecision",
     "ApprovalRecord",
+    "ApprovalStoreLoadError",
     "approved_tool_names",
     "consume",
     "denied_records",
+    "load_decisions_strict",
     "pending_records",
     "record_decision",
 ]

--- a/backend/graph/prompt_builder.py
+++ b/backend/graph/prompt_builder.py
@@ -80,6 +80,22 @@ EVICTION_ORDER: tuple[str, ...] = (
     "soul",
 )
 
+# Static guidance blocks are pinned (never evicted) and live in the cache
+# prefix. They are not listed in EVICTION_ORDER because they must always be
+# emitted. Every emitted section id must appear in either EVICTION_ORDER or
+# ``STATIC_GUIDANCE_SECTION_IDS`` — an orphan id would silently bypass the
+# stable/volatile partition and break prompt-cache fingerprinting.
+STATIC_GUIDANCE_SECTION_IDS: frozenset[str] = frozenset({
+    "_tool_result_error_contract",
+    "_tool_selection_guidance",
+    "_rag_memory_guidance",
+})
+
+# The closed set of section ids this module is allowed to emit. Used by the
+# runtime invariant check in ``_assemble_sections`` to prevent a newly added
+# section from being silently treated as volatile.
+KNOWN_SECTION_IDS: frozenset[str] = frozenset(EVICTION_ORDER) | STATIC_GUIDANCE_SECTION_IDS
+
 # Sections that belong to the prompt's stable prefix for prefix-cache reuse.
 # Anything not in this set is treated as volatile (per-turn state) and placed
 # after the cache breakpoint. Static guidance blocks (``_rag_memory_guidance``,
@@ -96,6 +112,15 @@ SECTIONS_IN_STABLE_PREFIX: frozenset[str] = frozenset({
     "_tool_selection_guidance",
     "_rag_memory_guidance",
 })
+
+# Module-load invariant: every id claimed as stable must be a known id. A
+# mismatch here (e.g. renaming a section without updating the set) would make
+# the stable/volatile split silently drop the renamed section from the cache
+# prefix.
+assert SECTIONS_IN_STABLE_PREFIX <= KNOWN_SECTION_IDS, (
+    "SECTIONS_IN_STABLE_PREFIX contains unknown section ids: "
+    f"{sorted(SECTIONS_IN_STABLE_PREFIX - KNOWN_SECTION_IDS)}"
+)
 
 _MEMORY_SCOPE_DIRS = ("project", "user", "agent")
 
@@ -618,6 +643,20 @@ def _assemble_sections(
     git_context = _build_git_context(base_dir, budget=budget)
     if git_context:
         sections.append(("git_context", git_context))
+
+    # Invariant: every emitted section id must be classified into the
+    # stable/volatile partition that drives prefix-cache fingerprinting. A
+    # new id that is neither in EVICTION_ORDER nor a static guidance id would
+    # default to the volatile suffix and silently break cache reuse the next
+    # time the prompt is assembled.
+    unknown = {sid for sid, _ in sections if sid not in KNOWN_SECTION_IDS}
+    if unknown:
+        raise AssertionError(
+            "prompt_builder emitted unclassified section ids: "
+            f"{sorted(unknown)}. Add them to EVICTION_ORDER or "
+            "STATIC_GUIDANCE_SECTION_IDS, and decide stable vs volatile via "
+            "SECTIONS_IN_STABLE_PREFIX."
+        )
 
     return _apply_eviction(
         sections,

--- a/backend/graph/session/__init__.py
+++ b/backend/graph/session/__init__.py
@@ -12,9 +12,10 @@ from graph.session.session_schema import (
     SessionCorruptError,
     _validate_session_id,
 )
-from graph.session.session_store import FrozenSessionPrefix
+from graph.session.session_store import FrozenPrefixRegistration, FrozenSessionPrefix
 
 __all__ = [
+    "FrozenPrefixRegistration",
     "FrozenSessionPrefix",
     "SessionManager",
     "SESSION_SCHEMA_VERSION",

--- a/backend/graph/session/session_index.py
+++ b/backend/graph/session/session_index.py
@@ -13,6 +13,7 @@ corruption by scanning the directory once.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import uuid
@@ -23,6 +24,19 @@ from graph.session.session_schema import _SESSION_ID_RE
 
 SESSION_INDEX_FILENAME = "_index.json"
 SESSION_INDEX_SCHEMA_VERSION = "session_index.v1"
+
+
+def _compute_sessions_checksum(sessions: dict[str, Any]) -> str:
+    """Stable SHA-256 digest over the sessions payload.
+
+    ``sort_keys=True`` makes the digest insensitive to dict ordering so the
+    same logical payload always hashes to the same value — but any change to
+    entry fields (title / updated_at / message_count) flips it, which is what
+    lets ``_normalize_loaded_index`` detect semantically-corrupt but
+    syntactically-valid sidecars.
+    """
+    canonical = json.dumps(sessions, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 class SessionIndexEntry(TypedDict):
@@ -104,6 +118,11 @@ def _normalize_loaded_index(raw: Any) -> dict[str, SessionIndexEntry] | None:
     sessions = raw.get("sessions")
     if not isinstance(sessions, dict):
         return None
+    checksum = raw.get("checksum")
+    if not isinstance(checksum, str):
+        return None
+    if checksum != _compute_sessions_checksum(sessions):
+        return None
     normalized: dict[str, SessionIndexEntry] = {}
     for session_id, entry in sessions.items():
         if not isinstance(session_id, str) or not _SESSION_ID_RE.match(session_id):
@@ -126,6 +145,7 @@ def _write_index(sessions_dir: Path, index: dict[str, SessionIndexEntry]) -> Non
     path = _index_path(sessions_dir)
     payload: dict[str, Any] = {
         "schema_version": SESSION_INDEX_SCHEMA_VERSION,
+        "checksum": _compute_sessions_checksum(index),
         "sessions": index,
     }
     tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")

--- a/backend/graph/session/session_store.py
+++ b/backend/graph/session/session_store.py
@@ -97,7 +97,6 @@ class FrozenSessionPrefix:
 # Per-session frozen prefix cache. Sub-agent contracts read this to reuse the
 # byte-identical leading prompt and maximise prompt-cache hits.
 _frozen_prefixes: dict[str, FrozenSessionPrefix] = {}
-_frozen_prefix_drift_logged: set[str] = set()
 _frozen_prefix_lock = threading.Lock()
 
 
@@ -537,17 +536,17 @@ class SessionStore:
         The prefix + tool list are the leading bytes of the system prompt that
         must stay byte-identical across the parent turn and every sub-agent
         run for DeepSeek / OpenAI / Anthropic prompt-cache hits. We freeze on
-        the first turn and never replace the snapshot — subsequent turns with
-        a different prefix log a drift warning (workspace edits, skills added
-        mid-session) so the loss of cache-eligibility is visible.
+        the first turn and never replace the snapshot — every subsequent turn
+        whose prefix fingerprint no longer matches emits a drift warning
+        (workspace edits, skills added mid-session) so repeated degradation
+        stays visible instead of being suppressed after the first occurrence.
         """
         _validate_session_id(session_id)
         fingerprint = _fingerprint_prefix(stable_prefix, tool_names)
         with _frozen_prefix_lock:
             existing = _frozen_prefixes.get(session_id)
             if existing is not None:
-                if existing.prefix_fingerprint != fingerprint and session_id not in _frozen_prefix_drift_logged:
-                    _frozen_prefix_drift_logged.add(session_id)
+                if existing.prefix_fingerprint != fingerprint:
                     logger.warning(
                         "session_prefix_drift session_id=%s — frozen prefix no "
                         "longer matches current prompt assembly; sub-agent "
@@ -574,7 +573,6 @@ class SessionStore:
         """Drop the frozen prefix (used when the session is deleted)."""
         with _frozen_prefix_lock:
             _frozen_prefixes.pop(session_id, None)
-            _frozen_prefix_drift_logged.discard(session_id)
 
     def get_session_meta(self, session_id: str) -> dict:
         data = self._read(session_id)

--- a/backend/graph/session/session_store.py
+++ b/backend/graph/session/session_store.py
@@ -97,8 +97,24 @@ class FrozenSessionPrefix:
 # Per-session frozen prefix cache. Sub-agent contracts read this to reuse the
 # byte-identical leading prompt and maximise prompt-cache hits.
 _frozen_prefixes: dict[str, FrozenSessionPrefix] = {}
-_frozen_prefix_drift_logged: set[str] = set()
 _frozen_prefix_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class FrozenPrefixRegistration:
+    """Result of :meth:`SessionStore.freeze_session_prefix`.
+
+    ``frozen`` is the currently-installed prefix snapshot. ``invalidated`` is
+    ``True`` on the turn a drifted fingerprint replaced a prior snapshot —
+    callers surface that as an SSE signal so the UI can show that the
+    provider prompt cache was dropped. ``previous_fingerprint`` carries the
+    fingerprint of the snapshot we replaced (``None`` on the first call for
+    the session).
+    """
+
+    frozen: FrozenSessionPrefix
+    invalidated: bool
+    previous_fingerprint: str | None
 
 
 def _get_or_create_lock(
@@ -531,37 +547,54 @@ class SessionStore:
         *,
         stable_prefix: str,
         tool_names: tuple[str, ...],
-    ) -> FrozenSessionPrefix:
-        """Record (on first call) or return the session's frozen prompt prefix.
+    ) -> FrozenPrefixRegistration:
+        """Record — or replace on drift — the session's frozen prompt prefix.
 
         The prefix + tool list are the leading bytes of the system prompt that
         must stay byte-identical across the parent turn and every sub-agent
-        run for DeepSeek / OpenAI / Anthropic prompt-cache hits. We freeze on
-        the first turn and never replace the snapshot — subsequent turns with
-        a different prefix log a drift warning (workspace edits, skills added
-        mid-session) so the loss of cache-eligibility is visible.
+        run for DeepSeek / OpenAI / Anthropic prompt-cache hits. On the first
+        call for a session we install the snapshot; on subsequent calls with
+        the same fingerprint we return it verbatim. A mid-session workspace
+        edit, skill change, or tool registry update produces a different
+        fingerprint — when that happens we replace the snapshot so sub-agents
+        spawned from the new parent prompt do not reuse stale cached bytes,
+        and return ``invalidated=True`` so the caller can emit an SSE event
+        for the UI.
         """
         _validate_session_id(session_id)
         fingerprint = _fingerprint_prefix(stable_prefix, tool_names)
         with _frozen_prefix_lock:
             existing = _frozen_prefixes.get(session_id)
-            if existing is not None:
-                if existing.prefix_fingerprint != fingerprint and session_id not in _frozen_prefix_drift_logged:
-                    _frozen_prefix_drift_logged.add(session_id)
-                    logger.warning(
-                        "session_prefix_drift session_id=%s — frozen prefix no "
-                        "longer matches current prompt assembly; sub-agent "
-                        "prompt-cache hits will degrade for this session.",
-                        session_id,
-                    )
-                return existing
+            if existing is not None and existing.prefix_fingerprint == fingerprint:
+                return FrozenPrefixRegistration(
+                    frozen=existing,
+                    invalidated=False,
+                    previous_fingerprint=None,
+                )
             frozen = FrozenSessionPrefix(
                 stable_prefix=stable_prefix,
                 tool_names=tool_names,
                 prefix_fingerprint=fingerprint,
             )
             _frozen_prefixes[session_id] = frozen
-            return frozen
+            if existing is None:
+                return FrozenPrefixRegistration(
+                    frozen=frozen,
+                    invalidated=False,
+                    previous_fingerprint=None,
+                )
+            logger.info(
+                "session_prefix_invalidated session_id=%s previous=%s current=%s "
+                "— workspace/skills edit detected; frozen prefix replaced.",
+                session_id,
+                existing.prefix_fingerprint,
+                fingerprint,
+            )
+            return FrozenPrefixRegistration(
+                frozen=frozen,
+                invalidated=True,
+                previous_fingerprint=existing.prefix_fingerprint,
+            )
 
     def get_frozen_session_prefix(self, session_id: str) -> FrozenSessionPrefix | None:
         """Return the frozen prefix for *session_id*, or ``None`` if unset."""
@@ -574,7 +607,6 @@ class SessionStore:
         """Drop the frozen prefix (used when the session is deleted)."""
         with _frozen_prefix_lock:
             _frozen_prefixes.pop(session_id, None)
-            _frozen_prefix_drift_logged.discard(session_id)
 
     def get_session_meta(self, session_id: str) -> dict:
         data = self._read(session_id)

--- a/backend/graph/session_manager.py
+++ b/backend/graph/session_manager.py
@@ -8,6 +8,7 @@ migration completes — plan to remove it after one release cycle.
 """
 
 from graph.session import (
+    FrozenPrefixRegistration,
     FrozenSessionPrefix,
     SESSION_SCHEMA_VERSION,
     SessionCorruptError,
@@ -16,6 +17,7 @@ from graph.session import (
 )
 
 __all__ = [
+    "FrozenPrefixRegistration",
     "FrozenSessionPrefix",
     "SessionManager",
     "SESSION_SCHEMA_VERSION",

--- a/backend/runtime/events.py
+++ b/backend/runtime/events.py
@@ -206,6 +206,33 @@ class NewResponseRuntimeEvent(_RuntimeEventBase):
     type: Literal["new_response"] = "new_response"
 
 
+class PrefixInvalidatedRuntimeEvent(_RuntimeEventBase):
+    """Frozen prompt-cache prefix was replaced mid-session.
+
+    Emitted by ``graph.agent.AgentManager.astream`` on the first turn where the
+    re-fingerprinted stable prefix diverges from the snapshot installed on an
+    earlier turn (typical trigger: a workspace file edited under
+    ``backend/workspace/*.md`` or a skill enabled/added under
+    ``backend/skills/``). Sub-agents spawned after this event will read the
+    fresh prefix through ``runtime.subagent.resolve_session_stable_prefix``
+    — their provider prompt cache is dropped for this turn, then warms again
+    against the new bytes.
+    """
+
+    type: Literal["prefix_invalidated"] = "prefix_invalidated"
+    session_id: Optional[str] = None
+    previous_fingerprint: Optional[str] = None
+    current_fingerprint: Optional[str] = None
+    reason: Optional[str] = Field(
+        default=None,
+        description=(
+            "Short tag describing why the prefix was invalidated "
+            "(e.g. ``workspace_or_skills_edit``). Free-form for forward "
+            "compatibility; the UI surfaces it as a pill."
+        ),
+    )
+
+
 class CompactionRuntimeEvent(_RuntimeEventBase):
     type: Literal["compaction_event"] = "compaction_event"
     from_turn: int
@@ -327,6 +354,7 @@ RuntimeEvent = Annotated[
         PlanUpdatedRuntimeEvent,
         VerificationResultRuntimeEvent,
         NewResponseRuntimeEvent,
+        PrefixInvalidatedRuntimeEvent,
         CompactionRuntimeEvent,
         WarningRuntimeEvent,
         DoneRuntimeEvent,
@@ -350,6 +378,7 @@ RUNTIME_EVENT_TYPES: tuple[str, ...] = (
     "plan_updated",
     "verification_result",
     "new_response",
+    "prefix_invalidated",
     "compaction_event",
     "warning",
     "done",

--- a/backend/runtime/events.schema.json
+++ b/backend/runtime/events.schema.json
@@ -457,6 +457,102 @@
       "title": "PlanUpdatedRuntimeEvent",
       "type": "object"
     },
+    "PrefixInvalidatedRuntimeEvent": {
+      "additionalProperties": false,
+      "description": "Frozen prompt-cache prefix was replaced mid-session.\n\nEmitted by ``graph.agent.AgentManager.astream`` on the first turn where the\nre-fingerprinted stable prefix diverges from the snapshot installed on an\nearlier turn (typical trigger: a workspace file edited under\n``backend/workspace/*.md`` or a skill enabled/added under\n``backend/skills/``). Sub-agents spawned after this event will read the\nfresh prefix through ``runtime.subagent.resolve_session_stable_prefix``\n\u2014 their provider prompt cache is dropped for this turn, then warms again\nagainst the new bytes.",
+      "properties": {
+        "current_fingerprint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Current Fingerprint"
+        },
+        "event_index": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Monotonic 1-based sequence number within a single turn.",
+          "title": "Event Index"
+        },
+        "previous_fingerprint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Previous Fingerprint"
+        },
+        "reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Short tag describing why the prefix was invalidated (e.g. ``workspace_or_skills_edit``). Free-form for forward compatibility; the UI surfaces it as a pill.",
+          "title": "Reason"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Stable per-turn identifier stamped by the transport adapter.",
+          "title": "Request Id"
+        },
+        "schema_version": {
+          "default": 2,
+          "description": "Version of the RuntimeEvent schema this event conforms to.",
+          "title": "Schema Version",
+          "type": "integer"
+        },
+        "session_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Session Id"
+        },
+        "type": {
+          "const": "prefix_invalidated",
+          "default": "prefix_invalidated",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "title": "PrefixInvalidatedRuntimeEvent",
+      "type": "object"
+    },
     "RetrievalErrorRuntimeEvent": {
       "additionalProperties": false,
       "description": "Non-fatal signal that a RAG retrieval attempt raised.\n\nEmitted when ``MemoryIndexer.retrieve`` (or the LLM-probe fallback) throws\nduring the pre-turn retrieval phase. The turn itself continues \u2014 callers\nstill record a retrieval miss via the metrics collector \u2014 but the reviewer\nsees the failure in the UI instead of the old silent swallow.",
@@ -1495,6 +1591,7 @@
       "new_response": "#/$defs/NewResponseRuntimeEvent",
       "plan_created": "#/$defs/PlanCreatedRuntimeEvent",
       "plan_updated": "#/$defs/PlanUpdatedRuntimeEvent",
+      "prefix_invalidated": "#/$defs/PrefixInvalidatedRuntimeEvent",
       "retrieval": "#/$defs/RetrievalRuntimeEvent",
       "retrieval_error": "#/$defs/RetrievalErrorRuntimeEvent",
       "token": "#/$defs/TokenRuntimeEvent",
@@ -1543,6 +1640,9 @@
     },
     {
       "$ref": "#/$defs/NewResponseRuntimeEvent"
+    },
+    {
+      "$ref": "#/$defs/PrefixInvalidatedRuntimeEvent"
     },
     {
       "$ref": "#/$defs/CompactionRuntimeEvent"

--- a/backend/runtime/helper_agent_runner.py
+++ b/backend/runtime/helper_agent_runner.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Any, Iterable, Literal
 
 from langchain.agents import create_agent
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import HumanMessage, ToolMessage
 
 from config import get_agent_runtime_limit
-from tools.contracts import normalize_tool_output
+from tools.contracts import is_tool_result_dict, normalize_tool_output
 
 
 @dataclass(frozen=True)
@@ -89,6 +90,33 @@ def extract_json_object(text: str) -> dict[str, Any]:
     raise ValueError("Helper agent did not return a valid JSON object.")
 
 
+def _render_raw_tool_output(raw_output: Any) -> str | None:
+    """Best-effort text rendering of a tool event payload.
+
+    Used to preserve pre-error stdout/stderr on the error envelope when the
+    normalized summary collapses to just the error message. Returns ``None``
+    when there is nothing useful to keep (e.g. the raw payload is already the
+    normalized envelope dict we are about to emit).
+    """
+
+    if raw_output is None or raw_output == "":
+        return None
+    if isinstance(raw_output, ToolMessage):
+        content = raw_output.content
+        if isinstance(content, str):
+            return content or None
+        rendered = _coerce_chunk_text(content)
+        return rendered or None
+    if isinstance(raw_output, str):
+        return raw_output
+    if is_tool_result_dict(raw_output):
+        return None
+    try:
+        return json.dumps(raw_output, ensure_ascii=False, default=str)
+    except Exception:
+        return str(raw_output) or None
+
+
 def _coerce_chunk_text(content: Any) -> str:
     if isinstance(content, str):
         return content
@@ -156,6 +184,10 @@ async def run_scoped_agent(
             run_id = event["run_id"]
             raw_output = event["data"].get("output", "")
             result = normalize_tool_output(event["name"], raw_output)
+            if result.status == "error" and result.partial_output is None:
+                rendered = _render_raw_tool_output(raw_output)
+                if rendered and rendered.strip() and rendered != result.summary:
+                    result.partial_output = rendered
             index = pending.pop(run_id, None)
             payload = {
                 "tool": event["name"],

--- a/backend/runtime/metrics_collector.py
+++ b/backend/runtime/metrics_collector.py
@@ -188,6 +188,11 @@ class MetricsCollector:
             "gauge",
             "Rolling ratio cache_read_tokens / total_input_tokens across LLM calls.",
         )
+        self._register(
+            "bioapex_approval_store_load_errors_total",
+            "counter",
+            "Turns where the on-disk approval store failed to load and destructive tools were forced closed.",
+        )
 
     # ------------------------------------------------------------------ #
     # Mutation helpers                                                     #
@@ -268,6 +273,10 @@ class MetricsCollector:
         else:
             self._inc_counter("bioapex_retrieval_cache_misses_total")
         self._recompute_hit_ratio()
+
+    def observe_approval_store_load_error(self) -> None:
+        """Record a turn where the on-disk approval store could not be loaded."""
+        self._inc_counter("bioapex_approval_store_load_errors_total")
 
     def observe_retrieval_error(self, *, error_type: str) -> None:
         """Record a retrieval attempt that raised.

--- a/backend/runtime/query_engine.py
+++ b/backend/runtime/query_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import time
@@ -71,6 +72,12 @@ async def dispatch_tool_batch(
 
 _logger = logging.getLogger(__name__)
 
+# Cap on how long the bounded-stream finally: block will wait for the inner
+# agent's ``aclose()`` to return. A wrapped tool (e.g. SLURM wait) that
+# swallows ``CancelledError`` can otherwise wedge teardown indefinitely even
+# after the turn wallclock deadline has already fired.
+_ACLOSE_TIMEOUT_S = 5.0
+
 
 async def _bounded_async_stream(
     agen: AsyncIterator[dict],
@@ -84,6 +91,12 @@ async def _bounded_async_stream(
     awaiting inside the inner agent receives a ``CancelledError`` at its
     next await point. The underlying generator is always closed in the
     ``finally`` block so tool ``finally:`` handlers run.
+
+    The ``aclose()`` call is itself bounded by ``_ACLOSE_TIMEOUT_S``: if the
+    inner generator swallows ``CancelledError`` (for example, a tool that
+    catches cancellation to finish a background RPC), teardown escalates to
+    an explicit ``task.cancel()`` and a second bounded wait, so the turn is
+    not held hostage by a stuck tool.
 
     Raises ``asyncio.TimeoutError`` to the caller when the deadline is hit.
     """
@@ -105,12 +118,28 @@ async def _bounded_async_stream(
     finally:
         aclose = getattr(agen, "aclose", None)
         if aclose is not None:
-            try:
-                await aclose()
-            except Exception:
+            aclose_task = asyncio.ensure_future(aclose())
+            done, _pending = await asyncio.wait(
+                {aclose_task}, timeout=_ACLOSE_TIMEOUT_S
+            )
+            if aclose_task not in done:
+                # Inner agent is stuck (e.g. a SLURM wait tool that swallows
+                # CancelledError). Escalate: request cancellation explicitly
+                # and give it one more bounded window to honor the cancel.
+                _logger.warning(
+                    "agent astream aclose exceeded %.1fs during bounded stream "
+                    "teardown; force-cancelling",
+                    _ACLOSE_TIMEOUT_S,
+                )
+                aclose_task.cancel()
+                with contextlib.suppress(BaseException):
+                    await asyncio.wait(
+                        {aclose_task}, timeout=_ACLOSE_TIMEOUT_S
+                    )
+            elif aclose_task.exception() is not None:
                 _logger.debug(
                     "agent astream aclose raised during bounded stream teardown",
-                    exc_info=True,
+                    exc_info=aclose_task.exception(),
                 )
 
 

--- a/backend/runtime/query_engine.py
+++ b/backend/runtime/query_engine.py
@@ -719,24 +719,34 @@ class QueryEngine:
         base_dir = getattr(self.agent_manager, "base_dir", None)
         approved_tool_runs: frozenset[str] = frozenset()
         denied_tool_runs: frozenset[str] = frozenset()
+        approval_store_unavailable = False
         if base_dir is not None:
             try:
-                approved_tool_runs = approval_store.approved_tool_names(
-                    base_dir, session_id
+                approved_tool_runs, denied_tool_runs = (
+                    approval_store.load_decisions_strict(base_dir, session_id)
                 )
-                denied_tool_runs = frozenset(
-                    record["tool_name"]
-                    for record in approval_store.denied_records(base_dir, session_id)
+            except approval_store.ApprovalStoreLoadError:
+                # Fail closed: an unreadable store could otherwise mask a prior
+                # deny decision and let a destructive tool through. The policy
+                # layer consults ``approval_store_unavailable`` before running
+                # any ``destructive=True`` tool; read-only tools continue to
+                # run so the agent can still make progress.
+                _logger.exception(
+                    "Approval store load failed for session %s; "
+                    "destructive tools will be blocked this turn.",
+                    session_id,
                 )
-            except Exception:
+                METRICS.observe_approval_store_load_error()
                 approved_tool_runs = frozenset()
                 denied_tool_runs = frozenset()
+                approval_store_unavailable = True
         policy_context = ToolPolicyExecutionContext(
             session_id=session_id,
             request_id=request_id,
             turn_id=request_id,
             approved_tool_runs=approved_tool_runs,
             denied_tool_runs=denied_tool_runs,
+            approval_store_unavailable=approval_store_unavailable,
         )
         ledger = TurnLedger(
             session_manager=session_manager,

--- a/backend/runtime/query_engine.py
+++ b/backend/runtime/query_engine.py
@@ -502,9 +502,7 @@ class QueryEngine:
                     if event_type == "token":
                         content = event.get("content")
                         if isinstance(content, str) and content:
-                            current_segment.append(content)
                             output_tokens += _count_tokens(content)
-                        yield event
                         if _budget_exceeded():
                             yield _budget_error_event()
                             return
@@ -512,6 +510,9 @@ class QueryEngine:
                         if cap_reason is not None:
                             yield _verifier_cap_error_event(cap_reason)
                             return
+                        if isinstance(content, str) and content:
+                            current_segment.append(content)
+                        yield event
                         continue
 
                     if event_type == "new_response":

--- a/backend/runtime/query_engine.py
+++ b/backend/runtime/query_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import itertools
 import json
 import logging
 import time
@@ -745,14 +746,12 @@ class QueryEngine:
             user_message=message,
         )
 
-        event_index = 0
+        event_counter = itertools.count(1)
 
         def _sse(payload: dict[str, Any]) -> str:
-            nonlocal event_index
             envelope = dict(payload)
-            event_index += 1
             envelope.setdefault("request_id", request_id)
-            envelope.setdefault("event_index", event_index)
+            envelope.setdefault("event_index", next(event_counter))
             # Validate + stamp schema_version through the transport-neutral
             # RuntimeEvent schema so SSE, WebSocket, and any future adapter share
             # one source of truth for event shapes.

--- a/backend/runtime/query_engine.py
+++ b/backend/runtime/query_engine.py
@@ -717,16 +717,15 @@ class QueryEngine:
 
         request_id = str(uuid.uuid4())
         base_dir = getattr(self.agent_manager, "base_dir", None)
-        approved_tool_runs: frozenset[str] = frozenset()
-        denied_tool_runs: frozenset[str] = frozenset()
+        approved_tool_runs: frozenset[tuple[str, str]] = frozenset()
+        denied_tool_runs: frozenset[tuple[str, str]] = frozenset()
         if base_dir is not None:
             try:
-                approved_tool_runs = approval_store.approved_tool_names(
+                approved_tool_runs = approval_store.approved_tool_runs(
                     base_dir, session_id
                 )
-                denied_tool_runs = frozenset(
-                    record["tool_name"]
-                    for record in approval_store.denied_records(base_dir, session_id)
+                denied_tool_runs = approval_store.denied_tool_runs(
+                    base_dir, session_id
                 )
             except Exception:
                 approved_tool_runs = frozenset()

--- a/backend/runtime/subagent.py
+++ b/backend/runtime/subagent.py
@@ -51,6 +51,16 @@ SUBAGENT_ARTIFACT_FILENAME = "subagent_run.json"
 SUBAGENT_SCHEMA_VERSION = "1.0.0"
 
 
+class _TokenBudgetExceeded(Exception):
+    """Internal signal raised from the event loop when the token budget trips.
+
+    Funneling the budget exit through the same ``except`` boundary as
+    recursion and generic errors keeps every terminal condition classified
+    in one place instead of splitting between an inline ``break`` and the
+    exception handler.
+    """
+
+
 def _tool_name(tool: Any) -> str:
     name = getattr(tool, "name", None)
     if isinstance(name, str) and name:
@@ -411,8 +421,9 @@ async def run_subagent(
                 tokens_used += _count_tokens(result.summary)
 
             if _over_budget():
-                status = "token_budget_exceeded"
-                break
+                raise _TokenBudgetExceeded()
+    except _TokenBudgetExceeded:
+        status = "token_budget_exceeded"
     except Exception as exc:  # noqa: BLE001 — classify at the boundary
         if _is_recursion_error(exc):
             status = "recursion_cap_exceeded"

--- a/backend/runtime/subagent.py
+++ b/backend/runtime/subagent.py
@@ -85,9 +85,11 @@ class SubAgentContract:
     turn of the parent session. When set, ``run_subagent`` prepends it verbatim
     to ``system_prompt`` so the provider's prefix cache matches the parent
     agent's leading bytes and ~95% of the sub-agent's input is served from
-    cache. Adding a skill or editing workspace files mid-session silently
-    invalidates the prefix and degrades the cache hit rate; see
-    :meth:`SessionManager.freeze_session_prefix` for the drift warning hook.
+    cache. Adding a skill or editing workspace files mid-session re-fingerprints
+    the prefix: the stale snapshot is dropped, the fresh one is installed,
+    a ``prefix_invalidated`` SSE event is emitted, and sub-agents launched on
+    subsequent turns read the fresh prefix. See
+    :meth:`SessionManager.freeze_session_prefix` for invalidation semantics.
     """
 
     name: str

--- a/backend/tests/test_agent_cache.py
+++ b/backend/tests/test_agent_cache.py
@@ -49,8 +49,8 @@ async def test_build_agent_cache_hits_on_consecutive_calls(tmp_path):
         "graph.agent.build_system_prompt_blocks",
         return_value=("STABLE", "VOLATILE"),
     ):
-        first = await manager._build_agent(session_id=session_id)
-        second = await manager._build_agent(session_id=session_id)
+        first, _ = await manager._build_agent(session_id=session_id)
+        second, _ = await manager._build_agent(session_id=session_id)
 
     assert first is second, "Cached agent must be reused across turns"
     assert creator.call_count == 1
@@ -69,8 +69,8 @@ async def test_build_agent_cache_invalidates_on_prompt_change(tmp_path):
         "graph.agent.build_system_prompt_blocks",
         side_effect=lambda *args, **kwargs: next(prompts),
     ):
-        first = await manager._build_agent(session_id=session_id)
-        second = await manager._build_agent(session_id=session_id)
+        first, _ = await manager._build_agent(session_id=session_id)
+        second, _ = await manager._build_agent(session_id=session_id)
 
     assert first is not second
     assert creator.call_count == 2
@@ -88,9 +88,9 @@ async def test_build_agent_cache_invalidates_on_tool_change(tmp_path):
         "graph.agent.build_system_prompt_blocks",
         return_value=("STABLE", "VOLATILE"),
     ):
-        first = await manager._build_agent(session_id=session_id)
+        first, _ = await manager._build_agent(session_id=session_id)
         manager.tools = [_FakeTool("read_file"), _FakeTool("run_bash")]
-        second = await manager._build_agent(session_id=session_id)
+        second, _ = await manager._build_agent(session_id=session_id)
 
     assert first is not second
     assert creator.call_count == 2
@@ -108,13 +108,13 @@ async def test_build_agent_fallback_llm_bypasses_cache(tmp_path):
         "graph.agent.build_system_prompt_blocks",
         return_value=("STABLE", "VOLATILE"),
     ):
-        primary = await manager._build_agent(session_id=session_id)
+        primary, _ = await manager._build_agent(session_id=session_id)
         await manager._build_agent(
             session_id=session_id,
             llm=fallback_llm,
             use_cache=False,
         )
-        primary_again = await manager._build_agent(session_id=session_id)
+        primary_again, _ = await manager._build_agent(session_id=session_id)
 
     assert primary is primary_again, (
         "Fallback build must not evict or overwrite the primary cache entry"
@@ -134,9 +134,9 @@ async def test_clear_session_runtime_drops_cached_agent(tmp_path):
         "graph.agent.build_system_prompt_blocks",
         return_value=("STABLE", "VOLATILE"),
     ):
-        first = await manager._build_agent(session_id=session_id)
+        first, _ = await manager._build_agent(session_id=session_id)
         manager.clear_session_runtime(session_id)
-        second = await manager._build_agent(session_id=session_id)
+        second, _ = await manager._build_agent(session_id=session_id)
 
     assert first is not second
     assert creator.call_count == 2
@@ -152,8 +152,8 @@ async def test_build_agent_without_session_id_does_not_cache(tmp_path):
         "graph.agent.build_system_prompt_blocks",
         return_value=("STABLE", "VOLATILE"),
     ):
-        first = await manager._build_agent(session_id=None)
-        second = await manager._build_agent(session_id=None)
+        first, _ = await manager._build_agent(session_id=None)
+        second, _ = await manager._build_agent(session_id=None)
 
     assert first is not second
     assert creator.call_count == 2

--- a/backend/tests/test_agent_manager.py
+++ b/backend/tests/test_agent_manager.py
@@ -56,7 +56,7 @@ async def test_concurrent_build_agent_across_sessions_preserves_both_entries(
     ):
         task_a = asyncio.create_task(manager._build_agent(session_id=session_a))
         task_b = asyncio.create_task(manager._build_agent(session_id=session_b))
-        agent_a, agent_b = await asyncio.gather(task_a, task_b)
+        (agent_a, _reg_a), (agent_b, _reg_b) = await asyncio.gather(task_a, task_b)
 
     # Both session entries survive — neither clobbered the other.
     keys = list(manager._agent_cache.keys())

--- a/backend/tests/test_approval_flow.py
+++ b/backend/tests/test_approval_flow.py
@@ -169,6 +169,7 @@ async def test_approval_endpoint_records_decision_to_store_and_audit(isolated_ap
     assert records[0]["decision"] == "approve"
     assert records[0]["actor"] == "alice"
     assert records[0]["rationale"] == "Verified on a disposable VM."
+    assert records[0]["args_hash"] == ""
 
     events = query_audit_events(
         agent_manager.base_dir,
@@ -194,6 +195,7 @@ async def test_next_turn_consumes_approved_tool_runs_from_store(isolated_approva
 
     session_id = agent_manager.session_manager.create_session()
 
+    args_hash = approval_store.compute_args_hash({"command": "ls"})
     approval_store.record_decision(
         agent_manager.base_dir,
         session_id=session_id,
@@ -202,6 +204,7 @@ async def test_next_turn_consumes_approved_tool_runs_from_store(isolated_approva
         decision="approve",
         actor="alice",
         rationale=None,
+        args_hash=args_hash,
     )
 
     captured: dict[str, object] = {}
@@ -219,7 +222,7 @@ async def test_next_turn_consumes_approved_tool_runs_from_store(isolated_approva
 
     policy_context = captured["policy_context"]
     assert policy_context is not None
-    assert "terminal" in policy_context.approved_tool_runs
+    assert ("terminal", args_hash) in policy_context.approved_tool_runs
     assert policy_context.denied_tool_runs == frozenset()
 
     done = next(item for item in payloads if item["type"] == "done")
@@ -240,6 +243,8 @@ async def test_denied_decision_surfaces_as_blocked_instead_of_reprompt(isolated_
     from tools.policy_types import ToolPolicyExecutionContext
 
     session_id = agent_manager.session_manager.create_session()
+    call_kwargs = {"path": "memory/note.md", "content": "hi"}
+    args_hash = approval_store.compute_args_hash(call_kwargs)
     approval_store.record_decision(
         agent_manager.base_dir,
         session_id=session_id,
@@ -248,13 +253,11 @@ async def test_denied_decision_surfaces_as_blocked_instead_of_reprompt(isolated_
         decision="deny",
         actor="bob",
         rationale="Not this run.",
+        args_hash=args_hash,
     )
 
-    denied = frozenset(
-        record["tool_name"]
-        for record in approval_store.denied_records(agent_manager.base_dir, session_id)
-    )
-    assert denied == frozenset({"write_file"})
+    denied = approval_store.denied_tool_runs(agent_manager.base_dir, session_id)
+    assert denied == frozenset({("write_file", args_hash)})
 
     runtime_tools = get_runtime_tools(agent_manager.base_dir)
     write_file = next(tool for tool in runtime_tools if tool.name == "write_file")
@@ -267,8 +270,149 @@ async def test_denied_decision_surfaces_as_blocked_instead_of_reprompt(isolated_
             denied_tool_runs=denied,
         )
     ):
-        summary, artifact = write_file._run(path="memory/note.md", content="hi")
+        summary, artifact = write_file._run(**call_kwargs)
 
     assert artifact["outcome"] == "blocked"
     assert artifact["metadata"]["policy"]["block_reason"] == "reviewer_denied_approval"
     assert "denied" in summary.lower() or "reviewer" in summary.lower()
+
+
+@pytest.mark.asyncio
+async def test_approval_for_different_args_does_not_authorize_new_call(isolated_approval_state):
+    """An approval bound to one args_hash must not authorize a call whose
+    kwargs hash to a different digest — the reviewer only OK'd that specific
+    invocation."""
+    from graph import approval_store
+    from graph.agent import agent_manager
+    from tools import get_runtime_tools
+    from tools.policy import tool_policy_context
+    from tools.policy_types import ToolPolicyExecutionContext
+
+    session_id = agent_manager.session_manager.create_session()
+    approved_args_hash = approval_store.compute_args_hash({"command": "ls /tmp"})
+    approval_store.record_decision(
+        agent_manager.base_dir,
+        session_id=session_id,
+        tool_name="terminal",
+        run_id="run-1",
+        decision="approve",
+        actor="alice",
+        rationale=None,
+        args_hash=approved_args_hash,
+    )
+
+    approved = approval_store.approved_tool_runs(agent_manager.base_dir, session_id)
+    assert approved == frozenset({("terminal", approved_args_hash)})
+
+    runtime_tools = get_runtime_tools(agent_manager.base_dir)
+    terminal = next(tool for tool in runtime_tools if tool.name == "terminal")
+
+    # Same tool, *different* args → must re-prompt.
+    with tool_policy_context(
+        ToolPolicyExecutionContext(
+            session_id=session_id,
+            request_id="req-1",
+            allowed_access_scope="execution",
+            approved_tool_runs=approved,
+        )
+    ):
+        summary, artifact = terminal._run(command="rm -rf /")
+
+    assert artifact["outcome"] == "needs_approval"
+    assert artifact["metadata"]["policy"]["status"] == "needs_approval"
+    assert summary.startswith("[NEEDS_APPROVAL]")
+
+
+def test_expired_approvals_are_dropped_on_load(isolated_approval_state, monkeypatch):
+    """A stored approval older than ``APPROVAL_TTL_SECONDS`` is silently
+    filtered out on load so a stale decision cannot authorize a later call."""
+    from datetime import datetime, timedelta, timezone
+
+    from graph import approval_store
+    from graph.agent import agent_manager
+
+    session_id = agent_manager.session_manager.create_session()
+    args_hash = approval_store.compute_args_hash({"command": "ls"})
+    approval_store.record_decision(
+        agent_manager.base_dir,
+        session_id=session_id,
+        tool_name="terminal",
+        run_id="run-1",
+        decision="approve",
+        actor="alice",
+        rationale=None,
+        args_hash=args_hash,
+    )
+
+    assert approval_store.approved_tool_runs(
+        agent_manager.base_dir, session_id
+    ) == frozenset({("terminal", args_hash)})
+
+    # Fast-forward the wall clock past the TTL by patching the module's
+    # ``datetime.now`` lookup. ``_load`` computes ``now`` as
+    # ``datetime.now(timezone.utc)`` so overriding the module attribute is
+    # enough.
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            base = datetime.now(timezone.utc) + timedelta(
+                seconds=approval_store.APPROVAL_TTL_SECONDS + 10
+            )
+            return base if tz is None else base.astimezone(tz)
+
+    monkeypatch.setattr(approval_store, "datetime", _FrozenDatetime)
+    try:
+        # After TTL elapses, the stored record is filtered out on load.
+        assert approval_store.approved_tool_runs(
+            agent_manager.base_dir, session_id
+        ) == frozenset()
+        assert approval_store.pending_records(
+            agent_manager.base_dir, session_id
+        ) == []
+    finally:
+        monkeypatch.undo()
+
+
+@pytest.mark.asyncio
+async def test_destructive_tool_always_reprompts_even_when_approved(isolated_approval_state):
+    """Approvals stored for a destructive manifest are ignored by the policy
+    layer — the reviewer must confirm each destructive call in the moment."""
+    from graph import approval_store
+    from graph.agent import agent_manager
+    from tools import get_runtime_tools
+    from tools.policy import tool_policy_context
+    from tools.policy_types import ToolPolicyExecutionContext
+
+    session_id = agent_manager.session_manager.create_session()
+    call_kwargs = {"path": "memory/note.md", "content": "hi"}
+    args_hash = approval_store.compute_args_hash(call_kwargs)
+    approval_store.record_decision(
+        agent_manager.base_dir,
+        session_id=session_id,
+        tool_name="write_file",
+        run_id="run-42",
+        decision="approve",
+        actor="alice",
+        rationale=None,
+        args_hash=args_hash,
+    )
+
+    approved = approval_store.approved_tool_runs(agent_manager.base_dir, session_id)
+    assert ("write_file", args_hash) in approved
+
+    runtime_tools = get_runtime_tools(agent_manager.base_dir)
+    write_file = next(tool for tool in runtime_tools if tool.name == "write_file")
+
+    with tool_policy_context(
+        ToolPolicyExecutionContext(
+            session_id=session_id,
+            request_id="req-1",
+            allowed_access_scope="execution",
+            approved_tool_runs=approved,
+        )
+    ):
+        summary, artifact = write_file._run(**call_kwargs)
+
+    assert artifact["outcome"] == "needs_approval"
+    assert artifact["metadata"]["policy"]["status"] == "needs_approval"
+    assert summary.startswith("[NEEDS_APPROVAL]")

--- a/backend/tests/test_approval_flow.py
+++ b/backend/tests/test_approval_flow.py
@@ -13,6 +13,7 @@ Exercises three guarantees from the issue:
    as a ``denied_tool_runs`` entry on the policy context.
 """
 import json
+import logging
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -272,3 +273,92 @@ async def test_denied_decision_surfaces_as_blocked_instead_of_reprompt(isolated_
     assert artifact["outcome"] == "blocked"
     assert artifact["metadata"]["policy"]["block_reason"] == "reviewer_denied_approval"
     assert "denied" in summary.lower() or "reviewer" in summary.lower()
+
+
+@pytest.mark.asyncio
+async def test_corrupt_approval_store_fails_closed_for_destructive_tools(
+    isolated_approval_state, caplog
+):
+    """A corrupt approvals file must not silently degrade to "no approvals".
+
+    When the on-disk store is unreadable the runtime must:
+    * log the load failure with a traceback,
+    * increment ``bioapex_approval_store_load_errors_total``,
+    * flip the policy context's ``approval_store_unavailable`` flag so the
+      policy layer blocks destructive tools (fail closed), while still
+      allowing read-only tools to run so the agent can make progress.
+    """
+    from api.chat import ChatRequest, chat
+    from graph.agent import agent_manager
+    from runtime.metrics_collector import METRICS
+    from tools import get_runtime_tools
+    from tools.policy import get_tool_policy_context, tool_policy_context
+
+    session_id = agent_manager.session_manager.create_session()
+
+    approvals_dir = agent_manager.base_dir / "storage" / "approvals"
+    approvals_dir.mkdir(parents=True, exist_ok=True)
+    corrupt_path = approvals_dir / f"{session_id}.json"
+    corrupt_path.write_text("{not valid json", encoding="utf-8")
+
+    before_counter = METRICS._counters.get(
+        "bioapex_approval_store_load_errors_total", {}
+    ).get((), 0.0)
+
+    captured: dict[str, object] = {}
+
+    async def fake_astream(_message, _history):
+        captured["policy_context"] = get_tool_policy_context()
+        yield {"type": "token", "content": "load error handled"}
+        yield {"type": "done"}
+
+    with caplog.at_level(logging.ERROR, logger="runtime.query_engine"):
+        with patch.object(agent_manager, "astream", fake_astream):
+            response = await chat(
+                ChatRequest(message="retry", session_id=session_id)
+            )
+            await _collect_sse_payloads(response)
+
+    policy_context = captured["policy_context"]
+    assert policy_context is not None
+    assert policy_context.approval_store_unavailable is True
+    assert policy_context.approved_tool_runs == frozenset()
+    assert policy_context.denied_tool_runs == frozenset()
+
+    after_counter = METRICS._counters.get(
+        "bioapex_approval_store_load_errors_total", {}
+    ).get((), 0.0)
+    assert after_counter == before_counter + 1.0
+
+    load_failure_logs = [
+        record
+        for record in caplog.records
+        if record.name == "runtime.query_engine"
+        and "Approval store load failed" in record.getMessage()
+    ]
+    assert load_failure_logs, "expected an error log with exc_info for the load failure"
+    assert load_failure_logs[0].exc_info is not None
+
+    runtime_tools = get_runtime_tools(agent_manager.base_dir)
+    write_file = next(tool for tool in runtime_tools if tool.name == "write_file")
+    read_file = next(tool for tool in runtime_tools if tool.name == "read_file")
+
+    (agent_manager.base_dir / "memory").mkdir(parents=True, exist_ok=True)
+    readable = agent_manager.base_dir / "memory" / "note.md"
+    readable.write_text("hi", encoding="utf-8")
+
+    with tool_policy_context(policy_context):
+        write_summary, write_artifact = write_file._run(
+            path="memory/note.md", content="hi"
+        )
+        read_summary, read_artifact = read_file._run(path="memory/note.md")
+
+    assert write_artifact["outcome"] == "blocked"
+    assert (
+        write_artifact["metadata"]["policy"]["block_reason"]
+        == "approval_store_unavailable"
+    )
+    assert "approval store" in write_summary.lower() or "destructive" in write_summary.lower()
+
+    assert read_artifact["outcome"] != "blocked"
+    assert read_summary

--- a/backend/tests/test_chat_streaming.py
+++ b/backend/tests/test_chat_streaming.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 import sys
@@ -371,6 +372,119 @@ async def test_chat_stream_runs_bounded_repair_pass_as_second_segment(isolated_c
     assert second_blocks == [{"type": "text", "text": "Repaired answer with citation."}]
     assert assistant_messages[0]["content"] == "Draft answer without citation."
     assert assistant_messages[1]["content"] == "Repaired answer with citation."
+
+
+@pytest.mark.asyncio
+async def test_bounded_async_stream_force_cancels_aclose_when_inner_swallows_cancel(
+    monkeypatch,
+):
+    """Issue #227: if the inner agent's aclose() blocks (e.g. a SLURM-wait
+    tool swallowing CancelledError), the bounded stream's finally: block must
+    not hang indefinitely. It should give up after ``_ACLOSE_TIMEOUT_S``,
+    emit a warning, and force-cancel the pending aclose task so the turn can
+    return.
+    """
+    import asyncio
+    import logging
+    import time
+
+    from runtime import query_engine
+    from runtime.query_engine import _bounded_async_stream
+
+    class BlockingAgen:
+        """Stand-in for the executor's async generator.
+
+        ``aclose`` blocks until it's explicitly cancelled — modeling a tool
+        (e.g. SLURM wait) whose cleanup will hang forever unless the
+        bounded-stream wrapper escalates with its own ``task.cancel()``.
+        """
+
+        def __init__(self) -> None:
+            self.cancel_count = 0
+            self._yielded = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self._yielded:
+                self._yielded = True
+                return {"type": "token", "content": "start"}
+            await asyncio.sleep(60)
+            raise StopAsyncIteration
+
+        async def aclose(self) -> None:
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                self.cancel_count += 1
+                # Honor the escalated cancel so the task actually completes
+                # — this is what distinguishes a forced teardown from the
+                # hang we're fixing.
+                raise
+
+    # Keep the test fast — we don't need the production 5s wait.
+    monkeypatch.setattr(query_engine, "_ACLOSE_TIMEOUT_S", 0.2)
+
+    inner = BlockingAgen()
+    # Wallclock deadline far in the future so teardown is triggered by
+    # ``aclose()`` (the caller exiting the ``async for``), not by the
+    # wallclock branch.
+    bounded = _bounded_async_stream(inner, time.monotonic() + 60.0)
+
+    observed: list[dict] = []
+    async for event in bounded:
+        observed.append(event)
+        break
+    assert observed == [{"type": "token", "content": "start"}]
+
+    start = time.monotonic()
+    with caplog_collect_warnings("runtime.query_engine") as records:
+        await bounded.aclose()
+    elapsed = time.monotonic() - start
+
+    # Teardown completes within a bounded window (first wait_for plus the
+    # force-cancel wait_for, each capped by the monkeypatched timeout).
+    assert elapsed < 2.0, f"aclose teardown took {elapsed:.2f}s"
+
+    # The inner generator's aclose received at least one cancellation —
+    # cancel was escalated rather than silently swallowed into a hang.
+    assert inner.cancel_count >= 1
+
+    # The warning log path fired, pointing operators at the stuck tool.
+    assert any(
+        "aclose exceeded" in record.getMessage() and record.levelno == logging.WARNING
+        for record in records
+    ), [r.getMessage() for r in records]
+
+
+@contextlib.contextmanager
+def caplog_collect_warnings(logger_name: str):
+    """Minimal stand-in for pytest's ``caplog`` fixture scoped to one logger.
+
+    Used by the bounded-stream teardown test so we can assert the warning
+    emitted when ``aclose()`` exceeds its budget without pulling in the
+    broader caplog fixture machinery.
+    """
+    import logging
+
+    records: list[logging.LogRecord] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _ListHandler(level=logging.WARNING)
+    target = logging.getLogger(logger_name)
+    previous_level = target.level
+    target.addHandler(handler)
+    target.setLevel(logging.WARNING)
+    try:
+        yield records
+    finally:
+        target.removeHandler(handler)
+        target.setLevel(previous_level)
+
 
 @pytest.mark.asyncio
 async def test_agent_astream_injects_compact_source_aware_retrieved_memory(isolated_chat_state):

--- a/backend/tests/test_claim_graph.py
+++ b/backend/tests/test_claim_graph.py
@@ -4,6 +4,7 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -387,3 +388,27 @@ def test_claim_graph_tool_returns_structured_result(tmp_path):
     assert artifact["status"] == "success"
     assert artifact["structured_payload"]["summary"]["claim_count"] == 1
     assert artifact["artifact_refs"][0]["artifact_type"] == "claim_graph"
+
+
+@pytest.mark.parametrize(
+    "field_name,secret_path",
+    [
+        ("evidence_card_paths", ".env"),
+        ("evidence_card_paths", "memory/.env.local"),
+        ("evidence_card_paths", "keys/id_rsa"),
+        ("evidence_review_paths", "secrets/server.pem"),
+        ("entity_grounding_paths", "memory/.env.production"),
+        ("workflow_run_paths", "keys/id_ed25519"),
+    ],
+)
+def test_claim_graph_tool_blocks_secret_like_paths(tmp_path, field_name, secret_path):
+    tool = ClaimGraphTool(base_dir=str(tmp_path))
+
+    summary, artifact = tool._run(**{field_name: [secret_path]})
+
+    assert "[BLOCKED]" in summary
+    assert artifact["tool_name"] == "claim_graph"
+    assert artifact["outcome"] == "blocked"
+    assert artifact["error"]["code"] == "blocked"
+    assert artifact["metadata"]["blocked_field"] == field_name
+    assert artifact["metadata"]["blocked_path"] == secret_path

--- a/backend/tests/test_evidence_review.py
+++ b/backend/tests/test_evidence_review.py
@@ -3,6 +3,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from artifacts import EvidenceReviewArtifact, load_artifact_document, lookup_artifact_registry
@@ -92,3 +94,29 @@ def test_evidence_review_tool_returns_structured_review_contract(tmp_path):
     assert artifact["structured_payload"]["review_status"] == "supported"
     assert artifact["structured_payload"]["source_facts"]
     assert artifact["artifact_refs"][0]["artifact_type"] == "evidence_review"
+
+
+@pytest.mark.parametrize(
+    "secret_path",
+    [
+        ".env",
+        "memory/.env",
+        "memory/.env.local",
+        "secrets/credentials.pem",
+        "keys/id_rsa",
+    ],
+)
+def test_evidence_review_tool_blocks_secret_like_paths(tmp_path, secret_path):
+    tool = EvidenceReviewTool(base_dir=str(tmp_path))
+
+    summary, artifact = tool._run(
+        question="What evidence supports anything?",
+        evidence_card_paths=[secret_path],
+    )
+
+    assert "[BLOCKED]" in summary
+    assert artifact["tool_name"] == "evidence_review"
+    assert artifact["outcome"] == "blocked"
+    assert artifact["error"]["code"] == "blocked"
+    assert artifact["metadata"]["blocked_field"] == "evidence_card_paths"
+    assert artifact["metadata"]["blocked_path"] == secret_path

--- a/backend/tests/test_files_content_type.py
+++ b/backend/tests/test_files_content_type.py
@@ -1,0 +1,118 @@
+"""Content-type and nosniff hardening for whitelisted file reads.
+
+Tool-output overflow files are written as ``.txt`` under
+``storage/tool-outputs/`` (see ``tools.policy_wrappers._persist_tool_output_overflow``)
+and are readable through the files API. A browser that fetches one must not
+be able to MIME-sniff embedded ``<script>`` and render it as HTML, so the
+``/files/raw``, ``/files/stream``, and ``HEAD /files/stream`` handlers must:
+
+- declare an explicit ``text/plain; charset=utf-8`` content type for ``.txt``, and
+- set ``X-Content-Type-Options: nosniff`` on the response.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+@pytest.fixture
+def files_app(tmp_path, monkeypatch):
+    from graph.agent import agent_manager
+    from api.files import router as files_router
+    from rate_limit import clear_buckets
+
+    monkeypatch.setenv("BIOAPEX_RATE_LIMIT_DISABLED", "1")
+    clear_buckets()
+
+    original_base_dir = agent_manager.base_dir
+    original_memory_indexer = agent_manager.memory_indexer
+    agent_manager.base_dir = tmp_path
+    agent_manager.memory_indexer = MagicMock()
+
+    for relpath in (
+        "artifacts",
+        "memory",
+        "workspace",
+        "skills",
+        "knowledge",
+        "storage/tool-outputs",
+    ):
+        (tmp_path / relpath).mkdir(parents=True, exist_ok=True)
+
+    app = FastAPI()
+    app.include_router(files_router, prefix="/api")
+
+    try:
+        yield app, tmp_path
+    finally:
+        agent_manager.base_dir = original_base_dir
+        agent_manager.memory_indexer = original_memory_indexer
+        clear_buckets()
+
+
+def _client(app: FastAPI) -> TestClient:
+    return TestClient(app, client=("127.0.0.1", 12345))
+
+
+def _write_overflow(base_dir: Path) -> str:
+    rel = "storage/tool-outputs/session-123/turn-abc-tool-deadbeef.txt"
+    target = base_dir / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("<script>alert(1)</script> plain overflow body\n", encoding="utf-8")
+    return rel
+
+
+def test_raw_overflow_txt_has_explicit_charset_and_nosniff(files_app):
+    app, base_dir = files_app
+    rel = _write_overflow(base_dir)
+
+    with _client(app) as client:
+        resp = client.get("/api/files/raw", params={"path": rel})
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "text/plain; charset=utf-8"
+    assert resp.headers["x-content-type-options"] == "nosniff"
+
+
+def test_stream_overflow_txt_has_explicit_charset_and_nosniff(files_app):
+    app, base_dir = files_app
+    rel = _write_overflow(base_dir)
+
+    with _client(app) as client:
+        resp = client.get("/api/files/stream", params={"path": rel})
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "text/plain; charset=utf-8"
+    assert resp.headers["x-content-type-options"] == "nosniff"
+
+
+def test_stream_head_overflow_txt_has_explicit_charset_and_nosniff(files_app):
+    app, base_dir = files_app
+    rel = _write_overflow(base_dir)
+
+    with _client(app) as client:
+        resp = client.head("/api/files/stream", params={"path": rel})
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "text/plain; charset=utf-8"
+    assert resp.headers["x-content-type-options"] == "nosniff"
+
+
+def test_raw_non_txt_still_gets_nosniff(files_app):
+    """nosniff is defense-in-depth for every raw response, not only ``.txt``."""
+    app, base_dir = files_app
+    (base_dir / "artifacts" / "data.json").write_text('{"k": 1}', encoding="utf-8")
+
+    with _client(app) as client:
+        resp = client.get("/api/files/raw", params={"path": "artifacts/data.json"})
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/json")
+    assert resp.headers["x-content-type-options"] == "nosniff"

--- a/backend/tests/test_helper_agent_runner.py
+++ b/backend/tests/test_helper_agent_runner.py
@@ -40,6 +40,135 @@ async def test_run_scoped_agent_uses_configured_helper_recursion_limit():
 
 
 @pytest.mark.asyncio
+async def test_run_scoped_agent_preserves_partial_output_on_tool_failure():
+    from langchain_core.messages import ToolMessage
+
+    from runtime.helper_agent_runner import run_scoped_agent
+
+    partial_stdout = (
+        "stdout line 1\nstdout line 2\n[ERROR] command exited with non-zero status"
+    )
+
+    class FakeAgent:
+        async def astream_events(self, payload, version="v2", config=None):
+            yield {
+                "event": "on_tool_start",
+                "name": "terminal",
+                "run_id": "run-1",
+                "data": {"input": {"command": "do_thing"}},
+            }
+            yield {
+                "event": "on_tool_end",
+                "name": "terminal",
+                "run_id": "run-1",
+                "data": {
+                    "output": ToolMessage(
+                        content=partial_stdout,
+                        status="error",
+                        tool_call_id="tc-1",
+                        name="terminal",
+                    ),
+                },
+            }
+            yield {
+                "event": "on_chat_model_stream",
+                "data": {"chunk": type("Chunk", (), {"content": "done"})()},
+            }
+
+    with patch(
+        "runtime.helper_agent_runner.create_agent",
+        return_value=FakeAgent(),
+    ), patch(
+        "runtime.helper_agent_runner.get_agent_runtime_limit",
+        return_value=1000,
+    ):
+        result = await run_scoped_agent(
+            llm=object(),
+            tools=[],
+            system_prompt="sys",
+            user_prompt="go",
+        )
+
+    assert len(result.tool_trace) == 1
+    trace = result.tool_trace[0]
+    envelope = trace["result"]
+    assert envelope["status"] == "error"
+    partial = envelope.get("partial_output")
+    # The ToolMessage path already preserves content in summary, so
+    # partial_output may stay None when it would just duplicate summary. What
+    # matters is that the trace keeps the pre-error text somewhere.
+    preserved_text = partial or envelope.get("summary", "")
+    assert "stdout line 1" in preserved_text
+    assert "stdout line 2" in preserved_text
+
+
+@pytest.mark.asyncio
+async def test_run_scoped_agent_captures_partial_output_when_summary_drops_it():
+    from runtime.helper_agent_runner import run_scoped_agent
+
+    pre_error_text = "progress: step 1 ok\nprogress: step 2 ok"
+
+    # Simulate a raw event payload where the text carrying the partial output
+    # differs from what normalize_tool_output collapses into the envelope
+    # summary. Using a bare `[ERROR] ...` string forces summary == error
+    # message; we splice the partial output in via a ToolMessage whose
+    # artifact is an envelope with a short summary but whose content retains
+    # the pre-error stdout.
+    from langchain_core.messages import ToolMessage
+    from tools.contracts import execution_error_result
+
+    _, error_envelope = execution_error_result("terminal", "command failed")
+
+    class FakeAgent:
+        async def astream_events(self, payload, version="v2", config=None):
+            yield {
+                "event": "on_tool_start",
+                "name": "terminal",
+                "run_id": "run-2",
+                "data": {"input": {"command": "do_thing"}},
+            }
+            yield {
+                "event": "on_tool_end",
+                "name": "terminal",
+                "run_id": "run-2",
+                "data": {
+                    "output": ToolMessage(
+                        content=pre_error_text,
+                        artifact=error_envelope,
+                        status="error",
+                        tool_call_id="tc-2",
+                        name="terminal",
+                    ),
+                },
+            }
+
+    with patch(
+        "runtime.helper_agent_runner.create_agent",
+        return_value=FakeAgent(),
+    ), patch(
+        "runtime.helper_agent_runner.get_agent_runtime_limit",
+        return_value=1000,
+    ):
+        result = await run_scoped_agent(
+            llm=object(),
+            tools=[],
+            system_prompt="sys",
+            user_prompt="go",
+        )
+
+    assert len(result.tool_trace) == 1
+    envelope = result.tool_trace[0]["result"]
+    assert envelope["status"] == "error"
+    # The envelope summary came from the structured artifact and does NOT
+    # contain the pre-error stdout. The runner must surface it as
+    # partial_output so the trace still exposes it.
+    assert "progress: step 1 ok" not in envelope["summary"]
+    assert envelope["partial_output"] is not None
+    assert "progress: step 1 ok" in envelope["partial_output"]
+    assert "progress: step 2 ok" in envelope["partial_output"]
+
+
+@pytest.mark.asyncio
 async def test_run_scoped_agent_explicit_recursion_limit_overrides_config():
     from runtime.helper_agent_runner import run_scoped_agent
 

--- a/backend/tests/test_prompt_builder.py
+++ b/backend/tests/test_prompt_builder.py
@@ -15,11 +15,14 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from graph.prompt_builder import (
     EVICTION_ORDER,
+    KNOWN_SECTION_IDS,
     MAX_COMPONENT_CHARS,
     MAX_MEMORY_INDEX_CHARS,
     MAX_RETRIEVED_MEMORY_BLOCK_CHARS,
     SECTIONS_IN_STABLE_PREFIX,
+    STATIC_GUIDANCE_SECTION_IDS,
     _apply_eviction,
+    _assemble_sections,
     build_anthropic_system_blocks,
     build_retrieved_memory_block,
     build_system_prompt,
@@ -1212,6 +1215,40 @@ class TestPromptCachePrefix:
             "_tool_selection_guidance",
             "_rag_memory_guidance",
         })
+
+    def test_known_section_ids_covers_stable_prefix_membership(self):
+        # Every id in SECTIONS_IN_STABLE_PREFIX must be a known section.
+        # A mismatch would silently drop a "stable" section from the cache
+        # prefix because the split uses set membership, not ordered tuples.
+        assert SECTIONS_IN_STABLE_PREFIX <= KNOWN_SECTION_IDS, (
+            "unknown ids in SECTIONS_IN_STABLE_PREFIX: "
+            f"{sorted(SECTIONS_IN_STABLE_PREFIX - KNOWN_SECTION_IDS)}"
+        )
+        # EVICTION_ORDER and STATIC_GUIDANCE_SECTION_IDS together define the
+        # closed set — with no overlap, since static guidance is never evicted.
+        assert set(EVICTION_ORDER).isdisjoint(STATIC_GUIDANCE_SECTION_IDS)
+        assert KNOWN_SECTION_IDS == frozenset(EVICTION_ORDER) | STATIC_GUIDANCE_SECTION_IDS
+
+    def test_assemble_sections_emits_no_orphan_ids(self, workspace):
+        # Every id emitted in either mode must be classified — otherwise the
+        # stable/volatile partition would silently treat a new section as
+        # volatile and drop it from the cache prefix.
+        for rag_mode in (False, True):
+            sections = _assemble_sections(
+                workspace, rag_mode, skill_entries=None
+            )
+            emitted_ids = {sid for sid, _ in sections}
+            orphans = emitted_ids - KNOWN_SECTION_IDS
+            assert not orphans, (
+                f"_assemble_sections emitted orphan ids (rag_mode={rag_mode}): "
+                f"{sorted(orphans)}"
+            )
+            # And each emitted id must be partitioned into exactly one of
+            # stable / volatile via SECTIONS_IN_STABLE_PREFIX.
+            for sid in emitted_ids:
+                assert (sid in SECTIONS_IN_STABLE_PREFIX) or (
+                    sid in KNOWN_SECTION_IDS - SECTIONS_IN_STABLE_PREFIX
+                ), f"section id {sid!r} is not classified as stable or volatile"
 
 
 class TestAnthropicSystemBlocks:

--- a/backend/tests/test_provenance_signing.py
+++ b/backend/tests/test_provenance_signing.py
@@ -1,0 +1,184 @@
+"""Tests for HMAC signing of artifact provenance records."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from artifacts.naming import prepare_run_directory
+from artifacts.provenance import (
+    ProvenanceSignatureError,
+    SIGNATURE_ALGORITHM,
+    materialize_provenance_bundle,
+    sign_provenance_payload,
+    verify_provenance_bundle,
+)
+from artifacts.schemas import WorkflowRun, load_artifact_document
+
+
+EXAMPLES_DIR = Path(__file__).parent.parent / "artifacts" / "examples"
+HMAC_KEY = "unit-test-hmac-key"
+
+
+def _make_payload() -> dict[str, object]:
+    return {
+        "schema_version": "1.0.0",
+        "artifact_type": "provenance",
+        "id": "provenance-demo",
+        "run_id": "run-20260318T193000Z-deadbeef",
+        "created_at": "2026-03-18T19:37:00Z",
+        "source_workflow": "demo-workflow",
+        "related_artifacts": [],
+        "workflow": {"name": "Demo Workflow", "slug": "demo-workflow"},
+        "used": [],
+    }
+
+
+def test_sign_provenance_payload_embeds_canonical_hmac(monkeypatch):
+    monkeypatch.setenv("BIOAPEX_PROVENANCE_HMAC_KEY", HMAC_KEY)
+
+    payload_a = _make_payload()
+    payload_b = _make_payload()
+    # Insert keys in a different order to prove canonical serialization is
+    # order-independent.
+    reordered = {key: payload_b.pop(key) for key in reversed(list(payload_b))}
+
+    sign_provenance_payload(payload_a)
+    sign_provenance_payload(reordered)
+
+    assert payload_a["signature"]["algorithm"] == SIGNATURE_ALGORITHM
+    assert len(payload_a["signature"]["digest"]) == 64
+    assert payload_a["signature"] == reordered["signature"]
+
+
+def test_sign_provenance_payload_fails_closed_without_key(monkeypatch):
+    monkeypatch.delenv("BIOAPEX_PROVENANCE_HMAC_KEY", raising=False)
+
+    with pytest.raises(ProvenanceSignatureError, match="not configured"):
+        sign_provenance_payload(_make_payload())
+
+
+def test_verify_provenance_bundle_happy_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("BIOAPEX_PROVENANCE_HMAC_KEY", HMAC_KEY)
+    payload = _make_payload()
+    sign_provenance_payload(payload)
+
+    path = tmp_path / "prov.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    verified = verify_provenance_bundle(path)
+    assert verified["signature"]["algorithm"] == SIGNATURE_ALGORITHM
+
+
+def test_verify_provenance_bundle_rejects_tampered_payload(monkeypatch, tmp_path):
+    monkeypatch.setenv("BIOAPEX_PROVENANCE_HMAC_KEY", HMAC_KEY)
+    payload = _make_payload()
+    sign_provenance_payload(payload)
+    # Tamper with a non-signature field after signing.
+    payload["workflow"]["name"] = "Tampered Workflow"
+
+    path = tmp_path / "prov.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ProvenanceSignatureError, match="mismatch"):
+        verify_provenance_bundle(path)
+
+
+def test_verify_provenance_bundle_rejects_missing_signature(monkeypatch, tmp_path):
+    monkeypatch.setenv("BIOAPEX_PROVENANCE_HMAC_KEY", HMAC_KEY)
+    payload = _make_payload()
+
+    path = tmp_path / "prov.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ProvenanceSignatureError, match="missing a signature"):
+        verify_provenance_bundle(path)
+
+
+def test_verify_provenance_bundle_rejects_wrong_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("BIOAPEX_PROVENANCE_HMAC_KEY", HMAC_KEY)
+    payload = _make_payload()
+    sign_provenance_payload(payload)
+
+    path = tmp_path / "prov.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setenv("BIOAPEX_PROVENANCE_HMAC_KEY", "different-key")
+    with pytest.raises(ProvenanceSignatureError, match="mismatch"):
+        verify_provenance_bundle(path)
+
+
+def test_verify_provenance_bundle_requires_configured_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("BIOAPEX_PROVENANCE_HMAC_KEY", HMAC_KEY)
+    payload = _make_payload()
+    sign_provenance_payload(payload)
+
+    path = tmp_path / "prov.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.delenv("BIOAPEX_PROVENANCE_HMAC_KEY", raising=False)
+    with pytest.raises(ProvenanceSignatureError, match="not configured"):
+        verify_provenance_bundle(path)
+
+
+def test_materialize_provenance_bundle_signs_and_links_ro_crate(monkeypatch, tmp_path):
+    monkeypatch.setenv("BIOAPEX_PROVENANCE_HMAC_KEY", HMAC_KEY)
+
+    run_document = load_artifact_document(EXAMPLES_DIR / "run.json")
+    assert isinstance(run_document, WorkflowRun)
+
+    layout = prepare_run_directory(
+        tmp_path,
+        run_document.workflow.name,
+        created_at=run_document.created_at,
+        run_id=run_document.run_id,
+    )
+
+    export_paths = materialize_provenance_bundle(
+        base_dir=tmp_path,
+        layout=layout,
+        run_document=run_document,
+        workflow_version="1.0.0",
+    )
+
+    provenance_path = tmp_path / export_paths[0]
+    ro_crate_path = tmp_path / export_paths[1]
+
+    prov_payload = verify_provenance_bundle(provenance_path)
+    assert prov_payload["signature"]["algorithm"] == SIGNATURE_ALGORITHM
+
+    ro_crate_payload = json.loads(ro_crate_path.read_text(encoding="utf-8"))
+    prov_entries = [
+        entry for entry in ro_crate_payload["@graph"] if entry.get("@id") == "../prov.json"
+    ]
+    assert prov_entries, "RO-Crate metadata must reference prov.json"
+    prov_entry = prov_entries[0]
+    assert prov_entry["signatureAlgorithm"] == SIGNATURE_ALGORITHM
+    assert prov_entry["signatureDigest"] == prov_payload["signature"]["digest"]
+
+
+def test_materialize_provenance_bundle_refuses_without_key(monkeypatch, tmp_path):
+    monkeypatch.delenv("BIOAPEX_PROVENANCE_HMAC_KEY", raising=False)
+
+    run_document = load_artifact_document(EXAMPLES_DIR / "run.json")
+    assert isinstance(run_document, WorkflowRun)
+
+    layout = prepare_run_directory(
+        tmp_path,
+        run_document.workflow.name,
+        created_at=run_document.created_at,
+        run_id=run_document.run_id,
+    )
+
+    with pytest.raises(ProvenanceSignatureError, match="not configured"):
+        materialize_provenance_bundle(
+            base_dir=tmp_path,
+            layout=layout,
+            run_document=run_document,
+            workflow_version="1.0.0",
+        )

--- a/backend/tests/test_runtime_query_engine.py
+++ b/backend/tests/test_runtime_query_engine.py
@@ -873,6 +873,46 @@ async def test_query_engine_run_turn_attaches_turn_result_to_budget_error():
 
 
 @pytest.mark.asyncio
+async def test_query_engine_does_not_yield_token_that_crosses_budget():
+    class _OverflowingTokenAgentManager(_FakeAgentManager):
+        async def astream(self, message: str, history: list[dict]) -> AsyncGenerator[dict, None]:
+            yield {"type": "token", "content": "warm up "}
+            yield {"type": "token", "content": "x" * 20000}
+            yield {"type": "token", "content": "unreachable tail"}
+            yield {"type": "done"}
+
+    engine = QueryEngine(_OverflowingTokenAgentManager())
+    turn = QueryTurnInput(message="hi", history=[])
+
+    with patch(
+        "runtime.query_engine.get_max_tokens_per_turn",
+        return_value=200,
+    ):
+        events = [event async for event in engine.run_harness_turn(turn)]
+
+    token_contents = [
+        event.get("content") for event in events if event.get("type") == "token"
+    ]
+    assert token_contents == ["warm up "], (
+        "token that crosses the budget must not be emitted to the client"
+    )
+    assert not any(
+        "unreachable tail" == event.get("content")
+        for event in events
+        if event.get("type") == "token"
+    )
+
+    error_events = [event for event in events if event.get("type") == "error"]
+    assert len(error_events) == 1
+    error = error_events[0]
+    assert error["turn_status"] == "budget_exceeded"
+    assert error["error"].startswith("turn budget exceeded at ")
+    assert events[-1] is error, (
+        "budget_error must be the final event; no tokens may follow it"
+    )
+
+
+@pytest.mark.asyncio
 async def test_query_engine_run_harness_turn_uses_agent_path_when_not_protocol_or_workflow():
     engine = QueryEngine(_FakeAgentManager())
     turn = QueryTurnInput(

--- a/backend/tests/test_session_frozen_prefix.py
+++ b/backend/tests/test_session_frozen_prefix.py
@@ -56,7 +56,7 @@ class TestFrozenSessionPrefix:
         )
         assert sm.get_frozen_session_prefix(session_id) is frozen_a
 
-    def test_drift_logs_warning_once(self, tmp_path, caplog):
+    def test_drift_logs_warning_every_time(self, tmp_path, caplog):
         from graph.session_manager import SessionManager
 
         session_id = _valid_session_id(2)
@@ -79,9 +79,18 @@ class TestFrozenSessionPrefix:
                 stable_prefix="stable-edited-again",
                 tool_names=("a",),
             )
+            # A call whose fingerprint matches the frozen snapshot must not log.
+            sm.freeze_session_prefix(
+                session_id,
+                stable_prefix="stable",
+                tool_names=("a",),
+            )
 
         drift_logs = [r for r in caplog.records if "session_prefix_drift" in r.message]
-        assert len(drift_logs) == 1, "Drift warning must log only once per session"
+        assert len(drift_logs) == 2, (
+            "Drift warning must fire on every drifting call so repeated "
+            "degradation stays visible; matching calls must not log."
+        )
 
     def test_delete_session_clears_frozen_prefix(self, tmp_path):
         from graph.session_manager import SessionManager

--- a/backend/tests/test_session_frozen_prefix.py
+++ b/backend/tests/test_session_frozen_prefix.py
@@ -35,53 +35,69 @@ def _valid_session_id(n: int) -> str:
 
 
 class TestFrozenSessionPrefix:
-    def test_freeze_returns_same_snapshot_on_repeat_calls(self, tmp_path):
+    def test_freeze_returns_same_snapshot_for_matching_fingerprint(self, tmp_path):
         from graph.session_manager import SessionManager
 
         session_id = _valid_session_id(1)
         sm = SessionManager(base_dir=tmp_path)
-        sm.create_session()  # Seed a session file so delete works later.
-        frozen_a = sm.freeze_session_prefix(
+        registration_a = sm.freeze_session_prefix(
             session_id,
             stable_prefix="<!-- Skills Snapshot -->\nx",
             tool_names=("read_file", "run_bash"),
         )
-        frozen_b = sm.freeze_session_prefix(
+        registration_b = sm.freeze_session_prefix(
             session_id,
-            stable_prefix="<!-- different -->\nz",
-            tool_names=("read_file",),
+            stable_prefix="<!-- Skills Snapshot -->\nx",
+            tool_names=("read_file", "run_bash"),
         )
-        assert frozen_a is frozen_b, (
-            "The first snapshot must be sticky — subsequent calls return it verbatim"
+        assert registration_a.frozen is registration_b.frozen, (
+            "A matching fingerprint must return the already-installed snapshot"
         )
-        assert sm.get_frozen_session_prefix(session_id) is frozen_a
+        assert registration_a.invalidated is False
+        assert registration_b.invalidated is False
+        assert sm.get_frozen_session_prefix(session_id) is registration_a.frozen
 
-    def test_drift_logs_warning_once(self, tmp_path, caplog):
+    def test_drift_invalidates_and_replaces_frozen_prefix(self, tmp_path, caplog):
         from graph.session_manager import SessionManager
 
         session_id = _valid_session_id(2)
         sm = SessionManager(base_dir=tmp_path)
 
-        sm.freeze_session_prefix(
+        first = sm.freeze_session_prefix(
             session_id,
             stable_prefix="stable",
             tool_names=("a",),
         )
+        assert first.invalidated is False
+        assert first.previous_fingerprint is None
 
-        with caplog.at_level("WARNING", logger="graph.session.session_store"):
-            sm.freeze_session_prefix(
+        with caplog.at_level("INFO", logger="graph.session.session_store"):
+            second = sm.freeze_session_prefix(
                 session_id,
                 stable_prefix="stable-edited",
                 tool_names=("a",),
             )
-            sm.freeze_session_prefix(
+            assert second.invalidated is True
+            assert second.previous_fingerprint == first.frozen.prefix_fingerprint
+            assert second.frozen.stable_prefix == "stable-edited"
+            assert sm.get_frozen_session_prefix(session_id) is second.frozen
+
+            third = sm.freeze_session_prefix(
                 session_id,
                 stable_prefix="stable-edited-again",
                 tool_names=("a",),
             )
+            assert third.invalidated is True
+            assert third.previous_fingerprint == second.frozen.prefix_fingerprint
+            assert third.frozen.stable_prefix == "stable-edited-again"
+            assert sm.get_frozen_session_prefix(session_id) is third.frozen
 
-        drift_logs = [r for r in caplog.records if "session_prefix_drift" in r.message]
-        assert len(drift_logs) == 1, "Drift warning must log only once per session"
+        invalidation_logs = [
+            r for r in caplog.records if "session_prefix_invalidated" in r.message
+        ]
+        assert len(invalidation_logs) == 2, (
+            "Every drifted fingerprint must log an invalidation, not be swallowed"
+        )
 
     def test_delete_session_clears_frozen_prefix(self, tmp_path):
         from graph.session_manager import SessionManager

--- a/backend/tests/test_session_frozen_prefix.py
+++ b/backend/tests/test_session_frozen_prefix.py
@@ -98,6 +98,66 @@ class TestFrozenSessionPrefix:
         sm.delete_session(session_id)
         assert sm.get_frozen_session_prefix(session_id) is None
 
+    def test_mid_session_skill_addition_triggers_prefix_drift(self, tmp_path, caplog):
+        """A new skill registered mid-session must change the assembled
+        stable prefix so ``freeze_session_prefix`` detects drift and logs
+        ``session_prefix_drift`` — otherwise the cache silently misses."""
+        from graph.prompt_builder import build_system_prompt_blocks
+        from graph.session_manager import SessionManager
+
+        # Minimal workspace so build_system_prompt_blocks has something to
+        # assemble. We only need the skills tree to be writable.
+        (tmp_path / "workspace").mkdir()
+        (tmp_path / "workspace" / "SOUL.md").write_text("soul", encoding="utf-8")
+        (tmp_path / "skills").mkdir()
+
+        session_id = _valid_session_id(42)
+        sm = SessionManager(base_dir=tmp_path)
+        sm.create_session()
+
+        turn1_stable, _ = build_system_prompt_blocks(tmp_path, rag_mode=False)
+        sm.freeze_session_prefix(
+            session_id,
+            stable_prefix=turn1_stable,
+            tool_names=("read_file",),
+        )
+
+        # Mid-session: register a new skill. This is the exact mutation the
+        # issue flags — the stable prefix changes shape but nothing else in
+        # the runtime notices.
+        skill_dir = tmp_path / "skills" / "new_skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            (
+                "---\nname: new_skill\ndescription: A new skill added mid-session.\n"
+                "category: bio/literature\n"
+                "requires_tools: [read_file]\nrequires_network: false\n"
+                "user_invocable: true\nspecies: any\nmodality: literature\n"
+                "stage: analysis\nstability: experimental\nsafety_level: low\n"
+                "---\n# Body\n"
+            ),
+            encoding="utf-8",
+        )
+
+        turn2_stable, _ = build_system_prompt_blocks(tmp_path, rag_mode=False)
+        assert turn1_stable != turn2_stable, (
+            "adding a skill mid-session must change the assembled stable "
+            "prefix — otherwise the drift hook has nothing to detect"
+        )
+
+        with caplog.at_level("WARNING", logger="graph.session.session_store"):
+            sm.freeze_session_prefix(
+                session_id,
+                stable_prefix=turn2_stable,
+                tool_names=("read_file",),
+            )
+
+        drift_logs = [r for r in caplog.records if "session_prefix_drift" in r.message]
+        assert len(drift_logs) == 1, (
+            "freeze_session_prefix must log session_prefix_drift when the "
+            "re-assembled prefix no longer matches the first-turn fingerprint"
+        )
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # SubAgentContract: compose stable prefix into the final system prompt

--- a/backend/tests/test_session_index.py
+++ b/backend/tests/test_session_index.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from graph.session.session_index import (
     SESSION_INDEX_FILENAME,
     SESSION_INDEX_SCHEMA_VERSION,
+    _compute_sessions_checksum,
     rebuild_index,
     remove_session_from_index,
     upsert_session_entry,
@@ -54,6 +55,7 @@ def _seed_synthetic_sessions_index(sessions_dir: Path, n: int) -> list[str]:
     }
     payload = {
         "schema_version": SESSION_INDEX_SCHEMA_VERSION,
+        "checksum": _compute_sessions_checksum(entries),
         "sessions": entries,
     }
     (sessions_dir / SESSION_INDEX_FILENAME).write_text(
@@ -265,6 +267,57 @@ class TestSessionIndexSidecar:
         payload = json.loads(sidecar.read_text())
         assert sid_gone not in payload["sessions"]
         assert sid_keep in payload["sessions"]
+
+    def test_sidecar_round_trip_preserves_checksum(self, sm, tmp_path):
+        """A freshly-written sidecar carries a checksum that matches its entries."""
+        sid = sm.create_session()
+        sm.save_message(sid, "user", "hello")
+
+        sidecar = tmp_path / "sessions" / SESSION_INDEX_FILENAME
+        payload = json.loads(sidecar.read_text())
+        assert payload["checksum"] == _compute_sessions_checksum(payload["sessions"])
+
+        # Re-load via list_sessions (which exercises _normalize_loaded_index)
+        # and confirm the sidecar was not rewritten due to checksum failure.
+        before_mtime = sidecar.stat().st_mtime_ns
+        listed = sm.list_sessions()
+        assert [row["id"] for row in listed] == [sid]
+        assert sidecar.stat().st_mtime_ns == before_mtime
+
+    def test_self_heal_when_checksum_missing(self, sm, tmp_path):
+        sid = sm.create_session()
+        sm.save_message(sid, "user", "hello")
+
+        sidecar = tmp_path / "sessions" / SESSION_INDEX_FILENAME
+        payload = json.loads(sidecar.read_text())
+        payload.pop("checksum", None)
+        sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+        listed = sm.list_sessions()
+        assert [row["id"] for row in listed] == [sid]
+        rebuilt = json.loads(sidecar.read_text())
+        assert "checksum" in rebuilt
+        assert rebuilt["checksum"] == _compute_sessions_checksum(rebuilt["sessions"])
+
+    def test_self_heal_when_entries_tampered_with_valid_json(self, sm, tmp_path):
+        """Semantically-corrupt payload (valid JSON, wrong checksum) triggers rebuild."""
+        sid = sm.create_session()
+        sm.save_message(sid, "user", "hello")
+
+        sidecar = tmp_path / "sessions" / SESSION_INDEX_FILENAME
+        payload = json.loads(sidecar.read_text())
+        # Mutate an entry without refreshing the checksum — simulates bitrot
+        # or an out-of-band edit that slips past schema/JSON validation.
+        payload["sessions"][sid]["message_count"] = 999
+        sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+        listed = sm.list_sessions()
+        assert [row["id"] for row in listed] == [sid]
+        # Rebuilt from the on-disk session file, so the tampered count is gone.
+        assert listed[0]["message_count"] == 1
+        rebuilt = json.loads(sidecar.read_text())
+        assert rebuilt["sessions"][sid]["message_count"] == 1
+        assert rebuilt["checksum"] == _compute_sessions_checksum(rebuilt["sessions"])
 
     def test_concurrent_writes_do_not_race_on_tmp_path(self, tmp_path):
         """Regression test: each writer must use a unique tmp filename.

--- a/backend/tests/test_subagent.py
+++ b/backend/tests/test_subagent.py
@@ -214,6 +214,8 @@ async def test_token_budget_exit_stops_streaming_and_persists(tmp_path):
     # counter to return a predictable value per call so the test does not
     # depend on the optional tiktoken backend.
     events = [
+        _tool_start_event("read_file", "memory/MEMORY.md", "run-budget-1"),
+        _tool_end_event("read_file", "contents", "run-budget-1"),
         _token_event("chunk-one "),
         _token_event("chunk-two "),
         _token_event("chunk-three "),
@@ -238,6 +240,14 @@ async def test_token_budget_exit_stops_streaming_and_persists(tmp_path):
         )
 
     assert artifact.status == "token_budget_exceeded"
+    # Budget-path exit must not masquerade as an error — the exception used
+    # internally to unwind the event loop is classified separately from the
+    # generic ``except Exception`` boundary.
+    assert artifact.error is None
+    # Partial transcript is preserved: the tool call that executed before
+    # the budget tripped must still appear in the persisted trace.
+    assert artifact.tool_trace
+    assert artifact.tool_trace[0]["tool"] == "read_file"
     # With 2 tokens consumed by system+user prompt and a budget of 2,
     # the very first streamed chunk should trip the limit.
     assert artifact.tokens_used >= 2
@@ -245,6 +255,8 @@ async def test_token_budget_exit_stops_streaming_and_persists(tmp_path):
     persisted = json.loads(Path(artifact.absolute_path).read_text(encoding="utf-8"))
     assert persisted["status"] == "token_budget_exceeded"
     assert persisted["tokens_used"] == artifact.tokens_used
+    assert persisted["error"] is None
+    assert persisted["outputs"]["tool_trace"][0]["tool"] == "read_file"
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_tool_policy.py
+++ b/backend/tests/test_tool_policy.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from graph.approval_store import compute_args_hash
 from tools import get_runtime_tools
 from tools.policy import (
     active_skill_specs_from_entries,
@@ -16,12 +17,13 @@ def test_policy_wrapper_allows_execution_tool_and_keeps_policy_metadata(tmp_path
     runtime_tools = get_runtime_tools(tmp_path)
     terminal = next(tool for tool in runtime_tools if tool.name == "terminal")
 
+    approved = frozenset({("terminal", compute_args_hash({"command": "pwd"}))})
     with tool_policy_context(
         ToolPolicyExecutionContext(
             session_id="session-1",
             request_id="request-1",
             allowed_access_scope="execution",
-            approved_tool_runs=frozenset({"terminal"}),
+            approved_tool_runs=approved,
         )
     ):
         summary, artifact = terminal._run(command="pwd")
@@ -57,24 +59,23 @@ def test_policy_wrapper_short_circuits_to_needs_approval_for_gated_tool(tmp_path
 
 def test_policy_wrapper_skips_approval_when_run_already_approved(tmp_path):
     runtime_tools = get_runtime_tools(tmp_path)
-    write_file = next(tool for tool in runtime_tools if tool.name == "write_file")
+    terminal = next(tool for tool in runtime_tools if tool.name == "terminal")
 
+    call_kwargs = {"command": "echo approved"}
+    approved = frozenset({("terminal", compute_args_hash(call_kwargs))})
     with tool_policy_context(
         ToolPolicyExecutionContext(
             session_id="session-1",
             request_id="request-1",
             allowed_access_scope="execution",
-            approved_tool_runs=frozenset({"write_file"}),
+            approved_tool_runs=approved,
         )
     ):
-        summary, artifact = write_file._run(
-            path="memory/notes.txt",
-            content="approved write",
-        )
+        summary, artifact = terminal._run(**call_kwargs)
 
     assert artifact["outcome"] == "success"
-    assert "Wrote memory/notes.txt" in summary
     assert artifact["metadata"]["policy"]["status"] == "allow"
+    assert "approved" in summary
 
 
 def test_policy_wrapper_annotates_successful_tool_results(tmp_path):

--- a/backend/tests/test_tool_policy_matrix.py
+++ b/backend/tests/test_tool_policy_matrix.py
@@ -48,6 +48,11 @@ from tools.registry import (  # noqa: E402
     validate_tool_classifications,
 )
 
+# ``evaluate_pre_tool_policy`` defaults the args_hash to ``""`` when no kwargs
+# flow through a wrapper. This matrix test is a synthetic policy-only probe,
+# so pre-approvals use the same sentinel to pair with that default.
+_NO_ARGS_HASH = ""
+
 
 # Maps posture's ``tools.*_enabled`` field to the registered tool names it
 # gates. Flags that do not correspond to a registered runtime tool (``slurm``,
@@ -78,28 +83,33 @@ def _disabled_tool_names(policy: ProductionHardeningPolicy) -> frozenset[str]:
     return frozenset(disabled)
 
 
-def _approved_tool_names(
+def _approved_tool_runs(
     policy: ProductionHardeningPolicy,
     manifests: tuple[ToolManifestEntry, ...],
     disabled: frozenset[str],
-) -> frozenset[str]:
+) -> frozenset[tuple[str, str]]:
     """Pre-approvals implied by the posture's approval threshold.
 
     A disabled tool is never pre-approved; the denial takes precedence so the
-    policy produces ``blocked`` rather than ``allow``.
+    policy produces ``blocked`` rather than ``allow``. Destructive manifests
+    are intentionally never pre-approved — the policy layer always re-prompts
+    for them regardless of what the posture says.
     """
     threshold = policy.approval_threshold
-    approved: set[str] = set()
+    approved: set[tuple[str, str]] = set()
     for manifest in manifests:
         if manifest.name in disabled:
             continue
         if not manifest.requires_approval:
             continue
+        if manifest.destructive:
+            # Destructive tools always re-prompt; an approval recorded here
+            # would be ignored by ``_user_has_approved`` anyway.
+            continue
         if threshold == "none":
-            approved.add(manifest.name)
+            approved.add((manifest.name, _NO_ARGS_HASH))
         elif threshold == "destructive_only":
-            if not manifest.destructive:
-                approved.add(manifest.name)
+            approved.add((manifest.name, _NO_ARGS_HASH))
         elif threshold == "all_risky":
             # Every requires-approval tool still needs explicit approval.
             continue
@@ -109,13 +119,14 @@ def _approved_tool_names(
 def _build_context(posture: HardeningPosture) -> ToolPolicyExecutionContext:
     policy = ProductionHardeningPolicy.from_posture(posture)
     disabled = _disabled_tool_names(policy)
-    approved = _approved_tool_names(policy, _MANIFESTS, disabled)
+    approved = _approved_tool_runs(policy, _MANIFESTS, disabled)
+    denied = frozenset((name, _NO_ARGS_HASH) for name in disabled)
     return ToolPolicyExecutionContext(
         session_id=f"session-{posture}",
         request_id=f"request-{posture}",
         allowed_access_scope="execution",
         approved_tool_runs=approved,
-        denied_tool_runs=disabled,
+        denied_tool_runs=denied,
     )
 
 
@@ -129,10 +140,15 @@ def _expected_status(
         return "blocked"
     if not manifest.requires_approval:
         return "allow"
+    # Destructive tools always re-prompt regardless of the posture's
+    # pre-approval semantics — ``_user_has_approved`` ignores stored
+    # approvals for them.
+    if manifest.destructive:
+        return "needs_approval"
     if policy.approval_threshold == "none":
         return "allow"
     if policy.approval_threshold == "destructive_only":
-        return "needs_approval" if manifest.destructive else "allow"
+        return "allow"
     # approval_threshold == "all_risky"
     return "needs_approval"
 
@@ -155,7 +171,7 @@ EXPECTED_MATRIX: dict[tuple[str, str], ToolPolicyStatus] = {
     ("uniprot_api", "dev"): "allow",
     ("ensembl_api", "dev"): "allow",
     ("read_file", "dev"): "allow",
-    ("write_file", "dev"): "allow",
+    ("write_file", "dev"): "needs_approval",
     ("search_knowledge_base", "dev"): "allow",
     # trusted-lab — python_repl disabled; destructive-only approval gates
     # write_file; other requires-approval tools pre-approved.

--- a/backend/tests/test_tool_policy_matrix.py
+++ b/backend/tests/test_tool_policy_matrix.py
@@ -258,7 +258,7 @@ def _fake_manifest(
         read_only=read_only,
         destructive=destructive,
         concurrency_safe=concurrency_safe,
-        planner_exposed=read_only,
+        planner_exposed=False,
         verifier_exposed=read_only,
         interrupt_behavior="restartable" if read_only else "avoid_interrupting",
         tool_validates_input=False,

--- a/backend/tests/test_tool_sandbox.py
+++ b/backend/tests/test_tool_sandbox.py
@@ -413,3 +413,39 @@ def test_evaluate_sandbox_arguments_network_none_blocks_any_url():
     )
     assert decision.status == "blocked"
     assert decision.block_reason == "sandbox_network_scope_violation"
+
+
+def test_public_network_blocks_loopback_ip_even_when_in_allowed_hosts():
+    """Regression: an allowed_hosts entry of '127.0.0.1' must not admit loopback."""
+    manifest = _manifest_with(
+        SandboxSpec(network_scope="public", allowed_hosts=("127.0.0.1",))
+    )
+    decision = evaluate_sandbox_arguments(
+        manifest, (), {"url": "http://127.0.0.1/admin"}
+    )
+    assert decision.status == "blocked"
+    assert decision.block_reason == "sandbox_network_scope_violation"
+    assert "private/reserved" in (decision.block_message or "")
+
+
+def test_public_network_blocks_localhost_even_when_in_allowed_hosts():
+    """Regression: an allowed_hosts entry of 'localhost' must not admit loopback resolution."""
+    manifest = _manifest_with(
+        SandboxSpec(network_scope="public", allowed_hosts=("localhost",))
+    )
+    decision = evaluate_sandbox_arguments(
+        manifest, (), {"url": "http://localhost/admin"}
+    )
+    assert decision.status == "blocked"
+    assert decision.block_reason == "sandbox_network_scope_violation"
+
+
+def test_public_network_admits_valid_public_host_in_allowed_hosts():
+    """The admit path still works for a genuinely public host."""
+    manifest = _manifest_with(
+        SandboxSpec(network_scope="public", allowed_hosts=("8.8.8.8",))
+    )
+    decision = evaluate_sandbox_arguments(
+        manifest, (), {"url": "http://8.8.8.8/dns"}
+    )
+    assert decision.status == "allow"

--- a/backend/tests/test_tool_sandbox.py
+++ b/backend/tests/test_tool_sandbox.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field
 sys.path.insert(0, str(Path(__file__).parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from graph.approval_store import compute_args_hash
 from tools import get_runtime_tools
 from tools.policy import (
     evaluate_sandbox_arguments,
@@ -34,13 +35,17 @@ from tools.policy_wrappers import PolicyWrappedTool
 from tools.registry import ToolManifestEntry
 
 
-def _approved_context(*approved: str) -> ToolPolicyExecutionContext:
+def _approved_context(*approved: tuple[str, str]) -> ToolPolicyExecutionContext:
     return ToolPolicyExecutionContext(
         session_id="session-1",
         request_id="request-1",
         allowed_access_scope="execution",
         approved_tool_runs=frozenset(approved),
     )
+
+
+def _approved_for(tool_name: str, kwargs: dict | None = None) -> ToolPolicyExecutionContext:
+    return _approved_context((tool_name, compute_args_hash(kwargs or {})))
 
 
 def _find_tool(tools, name: str) -> PolicyWrappedTool:
@@ -87,11 +92,9 @@ def test_write_file_sandbox_blocks_path_outside_allowed_roots(tmp_path):
     write_file = _find_tool(runtime_tools, "write_file")
     assert write_file.manifest.sandbox is not None
 
-    with tool_policy_context(_approved_context("write_file")):
-        summary, artifact = write_file._run(
-            path="artifacts/out.txt",
-            content="hello",
-        )
+    call_kwargs = {"path": "artifacts/out.txt", "content": "hello"}
+    with tool_policy_context(_approved_for("write_file", call_kwargs)):
+        summary, artifact = write_file._run(**call_kwargs)
 
     assert summary.startswith("[BLOCKED]")
     assert artifact["outcome"] == "blocked"
@@ -110,7 +113,7 @@ def test_fetch_url_sandbox_blocks_loopback_url_before_dispatch(tmp_path):
     runtime_tools = get_runtime_tools(tmp_path)
     fetch_url = _find_tool(runtime_tools, "fetch_url")
 
-    with tool_policy_context(_approved_context("fetch_url")):
+    with tool_policy_context(_approved_for("fetch_url", {"url": "http://127.0.0.1:8080/admin"})):
         summary, artifact = fetch_url._run(url="http://127.0.0.1:8080/admin")
 
     assert summary.startswith("[BLOCKED]")
@@ -125,11 +128,9 @@ def test_http_json_sandbox_blocks_private_ip_url_before_dispatch(tmp_path):
     runtime_tools = get_runtime_tools(tmp_path)
     http_json = _find_tool(runtime_tools, "http_json")
 
-    with tool_policy_context(_approved_context("http_json")):
-        summary, artifact = http_json._run(
-            method="GET",
-            url="http://10.0.0.5/api",
-        )
+    http_kwargs = {"method": "GET", "url": "http://10.0.0.5/api"}
+    with tool_policy_context(_approved_for("http_json", http_kwargs)):
+        summary, artifact = http_json._run(**http_kwargs)
 
     assert summary.startswith("[BLOCKED]")
     assert artifact["outcome"] == "blocked"
@@ -355,11 +356,9 @@ def test_sandbox_violation_surfaces_as_typed_blocked_envelope(tmp_path):
     runtime_tools = get_runtime_tools(tmp_path)
     write_file = _find_tool(runtime_tools, "write_file")
 
-    with tool_policy_context(_approved_context("write_file")):
-        summary, artifact = write_file._run(
-            path="../etc/passwd",
-            content="x",
-        )
+    call_kwargs = {"path": "../etc/passwd", "content": "x"}
+    with tool_policy_context(_approved_for("write_file", call_kwargs)):
+        summary, artifact = write_file._run(**call_kwargs)
 
     assert artifact["contract_version"] == "tool_result.v1"
     assert artifact["tool_name"] == "write_file"

--- a/backend/tools/claim_graph_tool.py
+++ b/backend/tools/claim_graph_tool.py
@@ -21,9 +21,11 @@ from langchain_core.tools import BaseTool
 from pydantic import BaseModel
 
 from evidence import ClaimGraphInput, run_claim_graph
+from hardening import is_secret_like_path
 
 from .contracts import (
     artifact_ref,
+    blocked_result,
     execution_error_result,
     invalid_input_result,
     success_result,
@@ -55,6 +57,19 @@ class ClaimGraphTool(BaseTool):
         workflow_run_paths: list[str] | None = None,
         include_related_artifacts: bool = True,
     ) -> tuple[str, dict]:
+        for field_name, candidates in (
+            ("evidence_card_paths", evidence_card_paths or []),
+            ("evidence_review_paths", evidence_review_paths or []),
+            ("entity_grounding_paths", entity_grounding_paths or []),
+            ("workflow_run_paths", workflow_run_paths or []),
+        ):
+            for candidate in candidates:
+                if is_secret_like_path(candidate):
+                    return blocked_result(
+                        self.name,
+                        "Reading credential / secret files is not allowed.",
+                        metadata={"blocked_field": field_name, "blocked_path": candidate},
+                    )
         try:
             payload = ClaimGraphInput(
                 evidence_card_paths=evidence_card_paths or [],

--- a/backend/tools/contracts.py
+++ b/backend/tools/contracts.py
@@ -91,6 +91,11 @@ class ToolResultEnvelope(BaseModel):
     error: ToolResultError | None = None
     metadata: dict[str, JsonLike] = Field(default_factory=dict)
     source_payload: JsonLike = None
+    # Pre-error stdout/stderr captured alongside an error envelope. Populated
+    # by trace consumers (see runtime.helper_agent_runner) so the full raw
+    # tool output survives even when the summary collapses to just the error
+    # message.
+    partial_output: str | None = None
 
 
 def artifact_ref(

--- a/backend/tools/evidence_review_tool.py
+++ b/backend/tools/evidence_review_tool.py
@@ -21,9 +21,11 @@ from langchain_core.tools import BaseTool
 from pydantic import BaseModel
 
 from evidence.review import EvidenceReviewInput, run_evidence_review
+from hardening import is_secret_like_path
 
 from .contracts import (
     artifact_ref,
+    blocked_result,
     empty_result,
     execution_error_result,
     invalid_input_result,
@@ -57,6 +59,13 @@ class EvidenceReviewTool(BaseTool):
         max_results: int = 5,
         max_evidence_cards: int = 3,
     ) -> tuple[str, dict]:
+        for candidate in evidence_card_paths or []:
+            if is_secret_like_path(candidate):
+                return blocked_result(
+                    self.name,
+                    "Reading credential / secret files is not allowed.",
+                    metadata={"blocked_field": "evidence_card_paths", "blocked_path": candidate},
+                )
         try:
             payload = EvidenceReviewInput(
                 question=question,

--- a/backend/tools/ncbi_eutils_tool.py
+++ b/backend/tools/ncbi_eutils_tool.py
@@ -5,12 +5,12 @@ Uses rate limit (no API key required; with API key can increase rate).
 Selection rule vs ``evidence_retrieval`` (issue #126): ``evidence_retrieval``
 is the canonical PubMed entry point — it wraps the same E-utilities calls and
 also persists durable BioAPEX evidence cards plus cached raw payloads. The
-planner helper agent therefore has ``ncbi_eutils`` hidden
-(``planner_exposed=False`` via ``_PLANNER_HIDDEN_TOOL_NAMES`` in
-``tools/registry.py``) so literature plans default to evidence-card output.
-The main agent and skills keep full access for cases where raw E-utilities
-are required (gene / protein DB lookups, ad-hoc esummary on non-PubMed DBs,
-XML retmode, or when evidence-card persistence is not wanted).
+planner helper agent therefore has ``ncbi_eutils`` hidden (no
+``planner_exposed=True`` in its ``tools/registry.py`` policy override) so
+literature plans default to evidence-card output. The main agent and skills
+keep full access for cases where raw E-utilities are required (gene /
+protein DB lookups, ad-hoc esummary on non-PubMed DBs, XML retmode, or when
+evidence-card persistence is not wanted).
 """
 from dataclasses import dataclass
 import json

--- a/backend/tools/policy.py
+++ b/backend/tools/policy.py
@@ -133,6 +133,17 @@ def evaluate_pre_tool_policy(
     if skill_violation is not None:
         return skill_violation
 
+    if manifest.destructive and getattr(context, "approval_store_unavailable", False):
+        return ToolPolicyDecision(
+            status="blocked",
+            block_reason="approval_store_unavailable",
+            block_message=(
+                f"Tool '{manifest.name}' is destructive and cannot run while the "
+                "approval store is unreadable; a corrupt store could otherwise "
+                "bypass a prior deny decision."
+            ),
+        )
+
     if manifest.requires_approval:
         if _user_has_denied(manifest, context):
             return ToolPolicyDecision(

--- a/backend/tools/policy.py
+++ b/backend/tools/policy.py
@@ -96,6 +96,8 @@ def set_active_skills_on_current_context(
 def evaluate_pre_tool_policy(
     manifest: ToolManifestEntry,
     context: ToolPolicyExecutionContext | None,
+    *,
+    args_hash: str = "",
 ) -> ToolPolicyDecision:
     settings = config.get_tool_policy_settings()
     if not bool(settings.get("enabled", True)):
@@ -134,7 +136,7 @@ def evaluate_pre_tool_policy(
         return skill_violation
 
     if manifest.requires_approval:
-        if _user_has_denied(manifest, context):
+        if _user_has_denied(manifest, context, args_hash):
             return ToolPolicyDecision(
                 status="blocked",
                 block_reason="reviewer_denied_approval",
@@ -142,7 +144,7 @@ def evaluate_pre_tool_policy(
                     f"Tool '{manifest.name}' was denied by the reviewer; proceed without it."
                 ),
             )
-        if not _user_has_approved(manifest, context):
+        if not _user_has_approved(manifest, context, args_hash):
             return ToolPolicyDecision(
                 status="needs_approval",
                 approval_reason="requires_approval",
@@ -330,23 +332,29 @@ def scoped_environment(allowed_env_vars: tuple[str, ...] | None) -> Iterator[Non
 def _user_has_approved(
     manifest: ToolManifestEntry,
     context: ToolPolicyExecutionContext,
+    args_hash: str,
 ) -> bool:
+    # Destructive tools always re-prompt regardless of any prior approval —
+    # the reviewer must confirm each destructive call in the moment. This is
+    # defense in depth on top of turn-end consume() so a stuck or late-arriving
+    # approval cannot silently authorize a second destructive dispatch.
+    if manifest.destructive:
+        return False
     approved = context.approved_tool_runs
     if not approved:
         return False
-    if manifest.name in approved:
-        return True
-    return False
+    return (manifest.name, args_hash) in approved
 
 
 def _user_has_denied(
     manifest: ToolManifestEntry,
     context: ToolPolicyExecutionContext,
+    args_hash: str,
 ) -> bool:
     denied = getattr(context, "denied_tool_runs", None)
     if not denied:
         return False
-    return manifest.name in denied
+    return (manifest.name, args_hash) in denied
 
 
 def annotate_tool_result(

--- a/backend/tools/policy.py
+++ b/backend/tools/policy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 import os
+import socket
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from pathlib import Path
@@ -290,14 +291,32 @@ def _public_network_violation_reason(
     host = (parsed.hostname or "").lower()
     if not host:
         return "URL has no host"
+
+    # Reject reserved/private/loopback addresses BEFORE consulting allowed_hosts
+    # so an entry like '127.0.0.1' or 'localhost' cannot short-circuit the
+    # public-scope guarantee by being added to the allowlist.
+    resolved: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    try:
+        resolved.append(ipaddress.ip_address(host))
+    except ValueError:
+        try:
+            for info in socket.getaddrinfo(host, None):
+                addr_str = info[4][0].split("%", 1)[0]
+                try:
+                    resolved.append(ipaddress.ip_address(addr_str))
+                except ValueError:
+                    continue
+        except OSError:
+            return f"host '{host}' could not be resolved"
+        if not resolved:
+            return f"host '{host}' could not be resolved"
+
+    for addr in resolved:
+        if addr.is_loopback or addr.is_link_local or addr.is_private:
+            return f"host '{host}' resolves to a private/reserved IP range"
+
     if allowed_hosts and host not in {h.lower() for h in allowed_hosts}:
         return f"host '{host}' is not in the sandbox allowed_hosts list"
-    try:
-        addr = ipaddress.ip_address(host)
-    except ValueError:
-        return None
-    if addr.is_loopback or addr.is_link_local or addr.is_private:
-        return f"host '{host}' resolves to a private/reserved IP range"
     return None
 
 

--- a/backend/tools/policy_types.py
+++ b/backend/tools/policy_types.py
@@ -74,18 +74,22 @@ class ToolPolicyExecutionContext:
     request_id: str | None = None
     turn_id: str | None = None
     allowed_access_scope: ToolAccessScope = "execution"
-    # Set of `tool_name` (or `f"{tool_name}:{run_id}"`) strings the user has
-    # already approved this turn. The runtime is responsible for populating
-    # this from the approval API; the policy layer only consults it.
-    approved_tool_runs: frozenset[str] = frozenset()
+    # Set of ``(tool_name, args_hash)`` tuples the reviewer has approved for
+    # this session. ``args_hash`` is the stable digest over the tool's
+    # canonical-JSON kwargs computed at gate-evaluation time; an approval for
+    # one argument set does not authorize a call with different arguments.
+    # Destructive manifests are filtered out at lookup time so they always
+    # re-prompt — see ``tools.policy._user_has_approved``.
+    approved_tool_runs: frozenset[tuple[str, str]] = frozenset()
     # Skills the router selected for this turn. When any active skill
     # declares a non-empty ``tools_allowed`` list, tool dispatch is
     # restricted to the union of those allowlists across active skills.
     active_skills: tuple[ActiveSkillSpec, ...] = ()
-    # Tool names the reviewer explicitly denied for this turn. Denied tools
-    # hard-block (rather than re-prompt) so the agent sees a blocked envelope
-    # and routes around the capability instead of spinning on the same gate.
-    denied_tool_runs: frozenset[str] = frozenset()
+    # ``(tool_name, args_hash)`` tuples the reviewer explicitly denied. Denied
+    # tools hard-block (rather than re-prompt) so the agent sees a blocked
+    # envelope and routes around the capability instead of spinning on the
+    # same gate.
+    denied_tool_runs: frozenset[tuple[str, str]] = frozenset()
 
 
 @dataclass(frozen=True)

--- a/backend/tools/policy_types.py
+++ b/backend/tools/policy_types.py
@@ -86,6 +86,11 @@ class ToolPolicyExecutionContext:
     # hard-block (rather than re-prompt) so the agent sees a blocked envelope
     # and routes around the capability instead of spinning on the same gate.
     denied_tool_runs: frozenset[str] = frozenset()
+    # True when the on-disk approval store could not be loaded for this
+    # turn. Destructive tools must fail closed in that case — a silent
+    # fallback to empty approved/denied sets could otherwise let a denied
+    # gated tool through.
+    approval_store_unavailable: bool = False
 
 
 @dataclass(frozen=True)

--- a/backend/tools/policy_wrappers.py
+++ b/backend/tools/policy_wrappers.py
@@ -19,6 +19,7 @@ from config import (
     get_tool_wallclock_default_s,
     get_tool_wallclock_override_s,
 )
+from graph.approval_store import compute_args_hash
 from runtime import hooks as runtime_hooks
 
 from .contracts import (
@@ -495,8 +496,18 @@ class PolicyWrappedTool(BaseTool):
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ):
-        decision = evaluate_pre_tool_policy(self.manifest, get_tool_policy_context())
-        if decision.status in ("blocked", "needs_approval"):
+        args_hash = compute_args_hash(kwargs)
+        decision = evaluate_pre_tool_policy(
+            self.manifest,
+            get_tool_policy_context(),
+            args_hash=args_hash,
+        )
+        # A hard block from access scope or the skill allowlist wins over a
+        # sandbox violation — no need to inspect args for a tool that isn't
+        # permitted at all. A ``needs_approval`` decision, however, must not
+        # mask a malformed-args block: destructive tools always return
+        # needs_approval, so sandbox violations would otherwise never surface.
+        if decision.status == "blocked":
             return decision
         sandbox_decision = evaluate_sandbox_arguments(self.manifest, args, kwargs)
         if sandbox_decision.status != "allow":

--- a/backend/tools/registry.py
+++ b/backend/tools/registry.py
@@ -138,8 +138,16 @@ _POLICY_OVERRIDES: dict[str, ToolPolicyMetadata] = {
         activity_summary_hint="State the code goal and the data or files it will touch before executing it.",
         result_summary_hint="Summarize the computed result, warnings, and any files or variables materially changed.",
     ),
-    "fetch_url": ToolPolicyMetadata(access_scope="inspection", verifier_exposed=True),
-    "http_json": ToolPolicyMetadata(access_scope="inspection", verifier_exposed=True),
+    "fetch_url": ToolPolicyMetadata(
+        access_scope="inspection",
+        planner_exposed=True,
+        verifier_exposed=True,
+    ),
+    "http_json": ToolPolicyMetadata(
+        access_scope="inspection",
+        planner_exposed=True,
+        verifier_exposed=True,
+    ),
     "ncbi_eutils": ToolPolicyMetadata(
         access_scope="inspection",
         evidence_requirement="recommended",
@@ -148,6 +156,7 @@ _POLICY_OVERRIDES: dict[str, ToolPolicyMetadata] = {
     "evidence_retrieval": ToolPolicyMetadata(
         access_scope="inspection",
         evidence_requirement="recommended",
+        planner_exposed=True,
         verifier_exposed=True,
     ),
     "evidence_review": ToolPolicyMetadata(
@@ -162,14 +171,20 @@ _POLICY_OVERRIDES: dict[str, ToolPolicyMetadata] = {
     "uniprot_api": ToolPolicyMetadata(
         access_scope="inspection",
         evidence_requirement="recommended",
+        planner_exposed=True,
         verifier_exposed=True,
     ),
     "ensembl_api": ToolPolicyMetadata(
         access_scope="inspection",
         evidence_requirement="recommended",
+        planner_exposed=True,
         verifier_exposed=True,
     ),
-    "read_file": ToolPolicyMetadata(access_scope="inspection", verifier_exposed=True),
+    "read_file": ToolPolicyMetadata(
+        access_scope="inspection",
+        planner_exposed=True,
+        verifier_exposed=True,
+    ),
     "write_file": ToolPolicyMetadata(
         access_scope="execution",
         destructive=True,
@@ -181,21 +196,11 @@ _POLICY_OVERRIDES: dict[str, ToolPolicyMetadata] = {
     "search_knowledge_base": ToolPolicyMetadata(
         access_scope="inspection",
         evidence_requirement="recommended",
+        planner_exposed=True,
         verifier_exposed=True,
     ),
     "plan_agent": ToolPolicyMetadata(access_scope="inspection"),
     "verification_agent": ToolPolicyMetadata(access_scope="inspection"),
-}
-
-# Tools that are read-only (so would normally be planner-exposed) but whose
-# planner visibility is intentionally suppressed to nudge the planner toward a
-# richer sibling tool. See issue #126 — the raw ``ncbi_eutils`` wrapper is
-# redundant with ``evidence_retrieval`` for planner-level literature work
-# because the latter also persists durable BioAPEX evidence cards. The main
-# agent and skills still see ``ncbi_eutils``; only the planner helper agent
-# has it hidden.
-_PLANNER_HIDDEN_TOOL_NAMES = {
-    "ncbi_eutils",
 }
 
 _READ_ONLY_TOOL_NAMES = {
@@ -271,7 +276,7 @@ def build_tool_manifest_entry(tool: Any) -> ToolManifestEntry:
     read_only = policy.read_only or tool.name in _READ_ONLY_TOOL_NAMES
     destructive = policy.destructive
     concurrency_safe = policy.concurrency_safe or tool.name in _CONCURRENCY_SAFE_TOOL_NAMES
-    planner_exposed = (policy.planner_exposed or read_only) and tool.name not in _PLANNER_HIDDEN_TOOL_NAMES
+    planner_exposed = policy.planner_exposed
     verifier_exposed = policy.verifier_exposed or read_only
     interrupt_behavior = policy.interrupt_behavior or _default_interrupt_behavior(
         read_only=read_only,

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -111,13 +111,15 @@ export default function ChatInput({
 
     if (!prefillText) return;
 
-    requestAnimationFrame(() => {
+    const rafId = requestAnimationFrame(() => {
       const el = textareaRef.current;
       if (!el) return;
       el.focus();
       const cursor = el.value.length;
       el.setSelectionRange(cursor, cursor);
     });
+
+    return () => cancelAnimationFrame(rafId);
   }, [prefillText, prefillRevision]);
 
   useEffect(() => {

--- a/frontend/src/components/chat/blocks/FeedBlock.test.tsx
+++ b/frontend/src/components/chat/blocks/FeedBlock.test.tsx
@@ -6,7 +6,6 @@ describe("FeedBlock", () => {
   it("renders the title and detail text", () => {
     render(
       <FeedBlock
-        kind="block"
         title="Evidence Review"
         detail="Reviewed two supporting papers."
       />
@@ -18,7 +17,7 @@ describe("FeedBlock", () => {
 
   it("omits the badge element when no badge is provided", () => {
     render(
-      <FeedBlock kind="block" title="Readiness Check" detail="All good." />
+      <FeedBlock title="Readiness Check" detail="All good." />
     );
 
     expect(screen.queryByText("supported")).toBeNull();
@@ -27,7 +26,6 @@ describe("FeedBlock", () => {
   it("renders the badge with matching tone classes when provided", () => {
     render(
       <FeedBlock
-        kind="block"
         title="Evidence Review"
         detail="Claims look supported."
         badge="supported"
@@ -44,7 +42,6 @@ describe("FeedBlock", () => {
   it("applies the warning tone to the outer container for warning states", () => {
     render(
       <FeedBlock
-        kind="block"
         title="Readiness"
         detail="Some checks still pending."
         tone="warning"

--- a/frontend/src/components/chat/blocks/FeedBlock.tsx
+++ b/frontend/src/components/chat/blocks/FeedBlock.tsx
@@ -9,7 +9,7 @@ export default function FeedBlock({
   detail,
   badge,
   tone = "default",
-}: FeedBlockDescriptor) {
+}: Omit<FeedBlockDescriptor, "kind" | "id">) {
   return (
     <div
       className={cn(

--- a/frontend/src/components/chat/blocks/FeedLine.tsx
+++ b/frontend/src/components/chat/blocks/FeedLine.tsx
@@ -8,7 +8,7 @@ export default function FeedLine({
   text,
   tone = "default",
   fullOutput,
-}: Omit<FeedLineDescriptor, "kind">) {
+}: Omit<FeedLineDescriptor, "kind" | "id">) {
   return (
     <p
       className={cn(

--- a/frontend/src/components/chat/blocks/FeedPlanning.test.tsx
+++ b/frontend/src/components/chat/blocks/FeedPlanning.test.tsx
@@ -6,7 +6,6 @@ describe("FeedPlanning", () => {
   it("renders each plan step as its own line", () => {
     render(
       <FeedPlanning
-        kind="planning"
         steps={[
           "Prepared a 2-step plan.",
           "1. Inspect memory.",
@@ -22,7 +21,7 @@ describe("FeedPlanning", () => {
 
   it("defaults to the active accent tone", () => {
     render(
-      <FeedPlanning kind="planning" steps={["Planning next steps."]} />
+      <FeedPlanning steps={["Planning next steps."]} />
     );
 
     expect(screen.getByText("Planning next steps.").className).toContain(
@@ -33,7 +32,6 @@ describe("FeedPlanning", () => {
   it("propagates the configured tone to every rendered line", () => {
     render(
       <FeedPlanning
-        kind="planning"
         steps={["Needs revision.", "Re-check citations."]}
         tone="warning"
       />
@@ -48,7 +46,7 @@ describe("FeedPlanning", () => {
   });
 
   it("renders nothing when no steps are provided", () => {
-    const { container } = render(<FeedPlanning kind="planning" steps={[]} />);
+    const { container } = render(<FeedPlanning steps={[]} />);
 
     expect(container.querySelectorAll("p")).toHaveLength(0);
   });

--- a/frontend/src/components/chat/blocks/FeedPlanning.tsx
+++ b/frontend/src/components/chat/blocks/FeedPlanning.tsx
@@ -6,7 +6,7 @@ import type { FeedPlanningDescriptor } from "./types";
 export default function FeedPlanning({
   steps,
   tone = "active",
-}: FeedPlanningDescriptor) {
+}: Omit<FeedPlanningDescriptor, "kind" | "id">) {
   return (
     <div className="space-y-1">
       {steps.map((step) => (

--- a/frontend/src/components/chat/blocks/FeedSection.test.tsx
+++ b/frontend/src/components/chat/blocks/FeedSection.test.tsx
@@ -28,9 +28,10 @@ describe("FeedSection", () => {
 
   it("renders line, block, and planning entries side by side", () => {
     const entries: FeedEntryDescriptor[] = [
-      { kind: "line", text: "Looked at memory.", tone: "active" },
+      { kind: "line", id: "line-memory", text: "Looked at memory.", tone: "active" },
       {
         kind: "block",
+        id: "block-evidence",
         title: "Evidence Review",
         detail: "All claims supported.",
         badge: "supported",
@@ -38,6 +39,7 @@ describe("FeedSection", () => {
       },
       {
         kind: "planning",
+        id: "planning-sample",
         steps: ["Prepared a 1-step plan.", "1. Inspect memory."],
         tone: "active",
       },
@@ -57,6 +59,7 @@ describe("FeedSection", () => {
     const entries: FeedEntryDescriptor[] = [
       {
         kind: "planning",
+        id: "planning-sample",
         steps: [
           "Prepared a 2-step plan.",
           "1. Review metadata.",
@@ -71,5 +74,71 @@ describe("FeedSection", () => {
     expect(screen.getByText("Prepared a 2-step plan.")).toBeTruthy();
     expect(screen.getByText("1. Review metadata.")).toBeTruthy();
     expect(screen.getByText("2. Draft the answer.")).toBeTruthy();
+  });
+
+  it("preserves entry DOM identity when entries reorder", () => {
+    // Index-based keys would cause React to reuse the first DOM node for
+    // whatever entry ends up at position 0, so the "Alpha." node reference
+    // would move with the text. Stable ids keep each node pinned to its
+    // entry so child state (e.g. ApprovalGate's confirming flag) survives.
+    const alpha: FeedEntryDescriptor = {
+      kind: "line",
+      id: "line-alpha",
+      text: "Alpha.",
+    };
+    const bravo: FeedEntryDescriptor = {
+      kind: "line",
+      id: "line-bravo",
+      text: "Bravo.",
+    };
+
+    const { rerender } = render(
+      <FeedSection live={false} title="Thinking" entries={[alpha, bravo]} />
+    );
+    const alphaBefore = screen.getByText("Alpha.");
+    const bravoBefore = screen.getByText("Bravo.");
+
+    rerender(
+      <FeedSection live={false} title="Thinking" entries={[bravo, alpha]} />
+    );
+
+    expect(screen.getByText("Alpha.")).toBe(alphaBefore);
+    expect(screen.getByText("Bravo.")).toBe(bravoBefore);
+  });
+
+  it("preserves entry DOM identity when a new entry is prepended", () => {
+    const alpha: FeedEntryDescriptor = {
+      kind: "line",
+      id: "line-alpha",
+      text: "Alpha.",
+    };
+    const bravo: FeedEntryDescriptor = {
+      kind: "line",
+      id: "line-bravo",
+      text: "Bravo.",
+    };
+    const charlie: FeedEntryDescriptor = {
+      kind: "line",
+      id: "line-charlie",
+      text: "Charlie.",
+    };
+
+    const { rerender } = render(
+      <FeedSection live={false} title="Thinking" entries={[alpha, bravo]} />
+    );
+    const alphaBefore = screen.getByText("Alpha.");
+    const bravoBefore = screen.getByText("Bravo.");
+
+    rerender(
+      <FeedSection
+        live={false}
+        title="Thinking"
+        entries={[charlie, alpha, bravo]}
+      />
+    );
+
+    expect(screen.getByText("Alpha.")).toBe(alphaBefore);
+    expect(screen.getByText("Bravo.")).toBe(bravoBefore);
+    expect(screen.getByText("Charlie.")).toBeTruthy();
   });
 });

--- a/frontend/src/components/chat/blocks/FeedSection.tsx
+++ b/frontend/src/components/chat/blocks/FeedSection.tsx
@@ -33,28 +33,23 @@ export default function FeedSection({
       </div>
 
       <div className="space-y-1.5">
-        {entries.map((entry, index) => {
+        {entries.map((entry) => {
           if (entry.kind === "block") {
-            return (
-              <FeedBlock
-                key={`${title}-${entry.title}-${entry.badge ?? "none"}-${index}`}
-                {...entry}
-              />
-            );
+            return <FeedBlock key={entry.id} {...entry} />;
           }
           if (entry.kind === "planning") {
-            return <FeedPlanning key={`${title}-planning-${index}`} {...entry} />;
+            return <FeedPlanning key={entry.id} {...entry} />;
           }
           if (entry.kind === "gate") {
             return (
               <ApprovalGate
-                key={`${title}-gate-${entry.block.run_id}-${index}`}
+                key={entry.id}
                 block={entry.block}
                 sessionId={sessionId}
               />
             );
           }
-          return <FeedLine key={`${title}-${entry.text}-${index}`} {...entry} />;
+          return <FeedLine key={entry.id} {...entry} />;
         })}
       </div>
     </div>

--- a/frontend/src/components/chat/blocks/types.ts
+++ b/frontend/src/components/chat/blocks/types.ts
@@ -7,8 +7,14 @@ export type FeedSectionKey =
   | "verification"
   | "workflow";
 
+// Every descriptor carries a stable `id` derived from upstream identifiers
+// (run_id / block index / step_id). FeedSection uses it as the React key so
+// reorders and filters don't remount children and discard internal state
+// such as ApprovalGate's pending/confirming flags.
+
 export interface FeedBlockDescriptor {
   kind: "block";
+  id: string;
   title: string;
   detail: string;
   badge?: string | null;
@@ -17,6 +23,7 @@ export interface FeedBlockDescriptor {
 
 export interface FeedPlanningDescriptor {
   kind: "planning";
+  id: string;
   steps: string[];
   tone?: FeedTone;
 }
@@ -28,6 +35,7 @@ export interface FeedLineFullOutputLink {
 
 export interface FeedLineDescriptor {
   kind: "line";
+  id: string;
   text: string;
   tone?: FeedTone;
   fullOutput?: FeedLineFullOutputLink;
@@ -35,6 +43,7 @@ export interface FeedLineDescriptor {
 
 export interface FeedGateDescriptor {
   kind: "gate";
+  id: string;
   block: SessionApprovalGateBlock;
 }
 

--- a/frontend/src/components/chat/turn-activity-feed.helpers.ts
+++ b/frontend/src/components/chat/turn-activity-feed.helpers.ts
@@ -131,12 +131,14 @@ function joinLabels(labels: string[], noun: string): string {
 }
 
 function summarizeRetrievalBlock(
-  results: RetrievalResult[]
+  results: RetrievalResult[],
+  blockIndex: number
 ): FeedLineDescriptor | null {
   if (results.length === 0) {
     return null;
   }
 
+  const id = `retrieval-${blockIndex}`;
   const labels = Array.from(
     new Set(
       results
@@ -148,6 +150,7 @@ function summarizeRetrievalBlock(
   if (labels.length === 0) {
     return {
       kind: "line",
+      id,
       text: "Looked at retrieved context.",
       tone: "active",
     };
@@ -156,6 +159,7 @@ function summarizeRetrievalBlock(
   if (labels.length === 1 && labels[0] === "memory") {
     return {
       kind: "line",
+      id,
       text: "Looked at memory.",
       tone: "active",
     };
@@ -163,13 +167,15 @@ function summarizeRetrievalBlock(
 
   return {
     kind: "line",
+    id,
     text: `Looked at ${joinLabels(labels, "source")}.`,
     tone: "active",
   };
 }
 
 function summarizePlanBlock(
-  block: Extract<SessionContentBlock, { type: "plan" }>
+  block: Extract<SessionContentBlock, { type: "plan" }>,
+  blockIndex: number
 ): FeedPlanningDescriptor {
   const stepCount = Array.isArray(block.plan.steps) ? block.plan.steps.length : null;
   const fallback =
@@ -184,17 +190,21 @@ function summarizePlanBlock(
 
   return {
     kind: "planning",
+    id: `plan-${block.run_id ?? blockIndex}`,
     steps: [summary, ...stepSummaries],
     tone: "active",
   };
 }
 
-function summarizeToolTraceLines(toolTrace: unknown): FeedLineDescriptor[] {
+function summarizeToolTraceLines(
+  toolTrace: unknown,
+  idPrefix: string
+): FeedLineDescriptor[] {
   if (!Array.isArray(toolTrace)) {
     return [];
   }
 
-  return toolTrace.flatMap((entry) => {
+  return toolTrace.flatMap((entry, index) => {
     if (!isObjectRecord(entry)) {
       return [];
     }
@@ -209,7 +219,10 @@ function summarizeToolTraceLines(toolTrace: unknown): FeedLineDescriptor[] {
       typeof entry.output === "string"
         ? entry.output
         : "";
-    const line = completedToolLine(tool, input, output);
+    const traceRunId =
+      typeof entry.run_id === "string" ? entry.run_id : null;
+    const id = `${idPrefix}-trace-${traceRunId ?? index}`;
+    const line = completedToolLine(tool, input, output, undefined, id);
     return line ? [line] : [];
   });
 }
@@ -353,11 +366,12 @@ function sentenceWithDetail(prefix: string, detail?: string | null): string {
 
 function summarizeVerificationChecks(
   verdict: Extract<SessionContentBlock, { type: "verification" }>["verdict"],
-  verification: Record<string, unknown> | null
+  verification: Record<string, unknown> | null,
+  idPrefix: string
 ): FeedLineDescriptor[] {
   const checks = Array.isArray(verification?.checks) ? verification.checks : [];
 
-  return checks.flatMap((check) => {
+  return checks.flatMap((check, index) => {
     if (!isObjectRecord(check)) {
       return [];
     }
@@ -366,8 +380,9 @@ function summarizeVerificationChecks(
       check.status === "pass" || check.status === "fail" || check.status === "not_run"
         ? check.status
         : null;
+    const rawName = typeof check.name === "string" ? check.name : null;
     const name = compactInline(
-      typeof check.name === "string" ? humanizeValue(check.name) : null,
+      rawName ? humanizeValue(rawName) : null,
       42
     );
     const note = compactUserFacingInline(
@@ -385,6 +400,7 @@ function summarizeVerificationChecks(
     return [
       {
         kind: "line",
+        id: `${idPrefix}-check-${rawName ?? index}`,
         text: sentenceWithDetail(prefix, note),
         tone: verificationDetailTone(verdict, status),
       },
@@ -394,7 +410,8 @@ function summarizeVerificationChecks(
 
 function summarizeVerificationActions(
   verdict: Extract<SessionContentBlock, { type: "verification" }>["verdict"],
-  verification: Record<string, unknown> | null
+  verification: Record<string, unknown> | null,
+  idPrefix: string
 ): FeedLineDescriptor[] {
   const actionValues = Array.isArray(verification?.repair_instructions)
     ? verification?.repair_instructions
@@ -403,7 +420,7 @@ function summarizeVerificationActions(
       : [];
   const seen = new Set<string>();
 
-  return actionValues.flatMap((value) => {
+  return actionValues.flatMap((value, index) => {
     if (typeof value !== "string") {
       return [];
     }
@@ -417,6 +434,7 @@ function summarizeVerificationActions(
     return [
       {
         kind: "line",
+        id: `${idPrefix}-action-${index}`,
         text,
         tone: verificationDetailTone(verdict),
       },
@@ -425,19 +443,22 @@ function summarizeVerificationActions(
 }
 
 function summarizeVerificationBlock(
-  block: Extract<SessionContentBlock, { type: "verification" }>
+  block: Extract<SessionContentBlock, { type: "verification" }>,
+  blockIndex: number
 ): FeedLineDescriptor[] {
   const tone = verificationTone(block.verdict);
   const verification = isObjectRecord(block.verification) ? block.verification : null;
+  const idPrefix = `verification-${block.run_id ?? blockIndex}`;
   const detailLines = [
-    ...summarizeToolTraceLines(block.tool_trace),
-    ...summarizeVerificationChecks(block.verdict, verification),
-    ...summarizeVerificationActions(block.verdict, verification),
+    ...summarizeToolTraceLines(block.tool_trace, idPrefix),
+    ...summarizeVerificationChecks(block.verdict, verification, idPrefix),
+    ...summarizeVerificationActions(block.verdict, verification, idPrefix),
   ];
 
   return [
     {
       kind: "line",
+      id: `${idPrefix}-outcome`,
       text: verificationOutcomeLine(block.verdict),
       tone,
     },
@@ -446,7 +467,8 @@ function summarizeVerificationBlock(
 }
 
 function summarizeWarningBlock(
-  block: Extract<SessionContentBlock, { type: "warning" }>
+  block: Extract<SessionContentBlock, { type: "warning" }>,
+  blockIndex: number
 ): FeedLineDescriptor | null {
   const message = compactInline(block.message, 160);
   if (!message) {
@@ -454,6 +476,7 @@ function summarizeWarningBlock(
   }
   return {
     kind: "line",
+    id: `warning-${blockIndex}`,
     text: message,
     tone: "warning",
   };
@@ -522,13 +545,15 @@ function outcomeTone(result?: ToolResultEnvelope): FeedTone {
 function startedToolLine(
   tool: string,
   input: string,
-  isPending: boolean
+  isPending: boolean,
+  id: string
 ): FeedLineDescriptor {
   const target = shouldShowToolTarget(tool)
     ? compactUserFacingInline(input)
     : null;
   return {
     kind: "line",
+    id,
     text: sentenceCase(
       target
         ? `${isPending ? "Running" : "Started"} ${toolPhrase(tool)} on ${target}.`
@@ -542,7 +567,8 @@ function completedToolLine(
   tool: string,
   input: string,
   output: string,
-  result?: ToolResultEnvelope
+  result: ToolResultEnvelope | undefined,
+  id: string
 ): FeedLineDescriptor | null {
   const target = shouldShowToolTarget(tool)
     ? compactUserFacingInline(input)
@@ -553,6 +579,7 @@ function completedToolLine(
   if (tool === "evidence_review") {
     return {
       kind: "line",
+      id,
       text: "Ran evidence review.",
       tone: outcomeTone(result),
       ...(fullOutput ? { fullOutput } : {}),
@@ -562,6 +589,7 @@ function completedToolLine(
   if (tool === "verification_agent") {
     return {
       kind: "line",
+      id,
       text: "Ran verification.",
       tone: outcomeTone(result),
       ...(fullOutput ? { fullOutput } : {}),
@@ -571,6 +599,7 @@ function completedToolLine(
   if (result?.status === "error") {
     return {
       kind: "line",
+      id,
       text: `${sentenceCase(toolPhrase(tool))} hit an error.`,
       tone: "error",
       ...(fullOutput ? { fullOutput } : {}),
@@ -580,6 +609,7 @@ function completedToolLine(
   if (tool.toLowerCase().includes("memory")) {
     return {
       kind: "line",
+      id,
       text: "Used memory.",
       tone: outcomeTone(result),
       ...(fullOutput ? { fullOutput } : {}),
@@ -588,6 +618,7 @@ function completedToolLine(
 
   return {
     kind: "line",
+    id,
     text: target
       ? `Ran ${toolPhrase(tool)} on ${target}.`
       : detail
@@ -642,6 +673,7 @@ function maybePushSectionPlaceholder(
   if (!hasPlanningEntry) {
     sections.planning.push({
       kind: "planning",
+      id: "planning-placeholder",
       steps: ["Planning next steps."],
       tone: "active",
     });
@@ -661,9 +693,11 @@ function summarizeWorkflowStep(step: WorkflowStepState): FeedLineDescriptor {
   const position = `${step.step_index}/${step.total_steps}`;
   const label = step.label ?? step.step_id;
   const attemptSuffix = step.attempt > 1 ? ` (attempt ${step.attempt})` : "";
+  const id = `workflow-${step.run_id}:${step.step_id}`;
   if (step.status === "running") {
     return {
       kind: "line",
+      id,
       text: `Step ${position}: ${label} — running${attemptSuffix}`,
       tone: "active",
     };
@@ -673,6 +707,7 @@ function summarizeWorkflowStep(step: WorkflowStepState): FeedLineDescriptor {
       typeof step.duration_ms === "number" ? ` in ${step.duration_ms} ms` : "";
     return {
       kind: "line",
+      id,
       text: `Step ${position}: ${label} — done${duration}${attemptSuffix}`,
       tone: "success",
     };
@@ -680,6 +715,7 @@ function summarizeWorkflowStep(step: WorkflowStepState): FeedLineDescriptor {
   const errorSuffix = step.error ? `: ${step.error}` : "";
   return {
     kind: "line",
+    id,
     text: `Step ${position}: ${label} — failed${attemptSuffix}${errorSuffix}`,
     tone: "error",
   };
@@ -689,6 +725,7 @@ function summarizeFallback(message: Message): FeedLineDescriptor {
   if (message.content.trim()) {
     return {
       kind: "line",
+      id: "fallback-drafting",
       text: "Drafting answer.",
       tone: "active",
     };
@@ -696,6 +733,7 @@ function summarizeFallback(message: Message): FeedLineDescriptor {
 
   return {
     kind: "line",
+    id: "fallback-preparing",
     text: "Preparing next step.",
     tone: "active",
   };
@@ -711,23 +749,29 @@ export function buildFeedSections(
   const pendingUses = new Map<string, Array<{ input: string; runId?: string }>>();
   let renderedPendingTool = false;
 
-  blocks.forEach((block) => {
+  blocks.forEach((block, blockIndex) => {
     switch (block.type) {
       case "text":
         break;
       case "retrieval": {
-        const line = summarizeRetrievalBlock(block.results);
+        const line = summarizeRetrievalBlock(block.results, blockIndex);
         if (line) {
           sections.thinking.push(line);
         }
         break;
       }
-      case "plan":
-        sections.thinking.push(...summarizeToolTraceLines(block.tool_trace));
-        sections.planning = [summarizePlanBlock(block)];
+      case "plan": {
+        const planPrefix = `plan-${block.run_id ?? blockIndex}`;
+        sections.thinking.push(
+          ...summarizeToolTraceLines(block.tool_trace, planPrefix)
+        );
+        sections.planning = [summarizePlanBlock(block, blockIndex)];
         break;
+      }
       case "verification":
-        sections.verification.push(...summarizeVerificationBlock(block));
+        sections.verification.push(
+          ...summarizeVerificationBlock(block, blockIndex)
+        );
         break;
       case "tool_use": {
         const key = toolBlockKey(block.tool, block.run_id);
@@ -747,7 +791,10 @@ export function buildFeedSections(
         if (shouldSuppressSectionToolLine(block.tool, hasVerificationBlock)) {
           maybePushSectionPlaceholder(sections, sectionKey, false);
         } else {
-          sections[sectionKey].push(startedToolLine(block.tool, block.input, isPending));
+          const id = `tool-start-${block.run_id ?? `idx-${blockIndex}`}`;
+          sections[sectionKey].push(
+            startedToolLine(block.tool, block.input, isPending, id)
+          );
         }
         break;
       }
@@ -761,11 +808,13 @@ export function buildFeedSections(
           pendingUses.delete(key);
         }
 
+        const id = `tool-end-${block.run_id ?? `idx-${blockIndex}`}`;
         const line = completedToolLine(
           block.tool,
           started?.input ?? "",
           block.output,
-          block.result
+          block.result,
+          id
         );
         if (line) {
           const sectionKey = sectionKeyForTool(block.tool);
@@ -781,11 +830,15 @@ export function buildFeedSections(
         break;
       }
       case "approval_gate": {
-        sections.thinking.push({ kind: "gate", block });
+        sections.thinking.push({
+          kind: "gate",
+          id: `gate-${block.run_id}`,
+          block,
+        });
         break;
       }
       case "warning": {
-        const line = summarizeWarningBlock(block);
+        const line = summarizeWarningBlock(block, blockIndex);
         if (line) {
           sections.thinking.push(line);
         }
@@ -805,7 +858,12 @@ export function buildFeedSections(
       maybePushSectionPlaceholder(sections, sectionKey, false);
     } else {
       sections[sectionKey].push(
-        startedToolLine(message.pendingTool.tool, message.pendingTool.input, true)
+        startedToolLine(
+          message.pendingTool.tool,
+          message.pendingTool.input,
+          true,
+          `tool-pending-${message.pendingTool.runId}`
+        )
       );
     }
   }

--- a/frontend/src/lib/api.stream-chat.test.ts
+++ b/frontend/src/lib/api.stream-chat.test.ts
@@ -446,6 +446,75 @@ describe("streamChat", () => {
     expect(surfacedErrors).toEqual([]);
   });
 
+  it("swallows reader.releaseLock() failures so overflow teardown cannot throw", async () => {
+    const cap = 256;
+    const oversizedLine = "data: " + "x".repeat(cap + 64);
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(oversizedLine));
+        controller.close();
+      },
+    });
+
+    // Wrap getReader so releaseLock() throws (simulating an already-released
+    // reader after cancel()), while read()/cancel() still behave normally.
+    const originalGetReader = stream.getReader.bind(stream);
+    Object.defineProperty(stream, "getReader", {
+      configurable: true,
+      value: (...args: unknown[]) => {
+        const reader = (originalGetReader as (...a: unknown[]) => ReadableStreamDefaultReader<Uint8Array>)(...args);
+        return new Proxy(reader, {
+          get(target, prop, receiver) {
+            if (prop === "releaseLock") {
+              return () => {
+                throw new DOMException(
+                  "The reader is not attached to any stream.",
+                  "InvalidStateError"
+                );
+              };
+            }
+            const value = Reflect.get(target, prop, receiver);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        });
+      },
+    });
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(stream, {
+        headers: { "Content-Type": "text/event-stream" },
+        status: 200,
+      })
+    );
+
+    const overflows: Array<{ bufferedBytes: number; maxBufferBytes: number }> = [];
+    const surfacedErrors: string[] = [];
+
+    await expect(
+      streamChat(
+        "Send a giant payload.",
+        "session-overflow-release",
+        {
+          onStreamOverflow: (event) => {
+            overflows.push({
+              bufferedBytes: event.bufferedBytes,
+              maxBufferBytes: event.maxBufferBytes,
+            });
+          },
+          onError: (error) => {
+            surfacedErrors.push(error);
+          },
+        },
+        { maxBufferBytes: cap }
+      )
+    ).resolves.toBeUndefined();
+
+    expect(overflows).toHaveLength(1);
+    expect(overflows[0].maxBufferBytes).toBe(cap);
+    expect(surfacedErrors).toEqual([]);
+  });
+
   it("drops events whose request_id does not match the latched in-flight id", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       sseResponse(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -535,6 +535,11 @@ export async function streamChat(
       }
     }
   } finally {
-    reader.releaseLock();
+    try {
+      reader.releaseLock();
+    } catch {
+      // The reader may already be released (e.g. after an overflow-driven
+      // cancel() resolves). Swallow so teardown cannot mask the primary flow.
+    }
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -449,7 +449,9 @@ export async function streamChat(
     },
   });
 
-  const dispatcher = createChatStreamDispatcher(callbacks);
+  const dispatcher = createChatStreamDispatcher(callbacks, {
+    expectedRequestId: options.requestId,
+  });
 
   if (!response.ok || !response.body) {
     const text = await response.text().catch(() => response.statusText);

--- a/frontend/src/lib/chat-stream-events.test.ts
+++ b/frontend/src/lib/chat-stream-events.test.ts
@@ -185,6 +185,34 @@ describe("createChatStreamDispatcher request-id correlation", () => {
     expect(onRequestIdMismatch).toHaveBeenCalledTimes(1);
     expect(dispatcher.expectedRequestId()).toBe("req-seeded");
   });
+
+  it("rejects a late prior-turn event even when it arrives before any current-turn event", () => {
+    const onEvent = vi.fn();
+    const onToken = vi.fn();
+    const onRequestIdMismatch = vi.fn();
+    const dispatcher = createChatStreamDispatcher(
+      { onEvent, onToken, onRequestIdMismatch },
+      { expectedRequestId: "req-current" }
+    );
+
+    dispatcher.dispatch({
+      type: "token",
+      content: "stale-from-prior-turn",
+      request_id: "req-previous",
+    });
+    dispatcher.dispatch({
+      type: "token",
+      content: "current",
+      request_id: "req-current",
+    });
+
+    expect(onRequestIdMismatch).toHaveBeenCalledTimes(1);
+    const [droppedEvent] = onRequestIdMismatch.mock.calls[0];
+    expect(droppedEvent.request_id).toBe("req-previous");
+    expect(onToken).toHaveBeenCalledTimes(1);
+    expect(onToken).toHaveBeenCalledWith("current");
+    expect(dispatcher.expectedRequestId()).toBe("req-current");
+  });
 });
 
 describe("parseChatStreamDataPayload", () => {

--- a/frontend/src/lib/chat-stream-events.ts
+++ b/frontend/src/lib/chat-stream-events.ts
@@ -150,6 +150,15 @@ export function parseChatStreamEventPayload(payload: unknown): ChatStreamEvent {
       };
     case "new_response":
       return { type: "new_response", ...base };
+    case "prefix_invalidated":
+      return {
+        type: "prefix_invalidated",
+        session_id: event.session_id ?? undefined,
+        previous_fingerprint: event.previous_fingerprint ?? undefined,
+        current_fingerprint: event.current_fingerprint ?? undefined,
+        reason: event.reason ?? undefined,
+        ...base,
+      };
     case "compaction_event":
       return {
         type: "compaction_event",

--- a/frontend/src/lib/chat-stream-reducer.test.ts
+++ b/frontend/src/lib/chat-stream-reducer.test.ts
@@ -833,6 +833,209 @@ describe("applyStreamEvent per-event coverage", () => {
     expect(statuses).toEqual(["ok", "running"]);
   });
 
+  it("rejects a late workflow_step_started after ok and preserves terminal fields", () => {
+    let state = freshState();
+    state = reduceEvent(
+      state,
+      {
+        type: "workflow_step_started",
+        workflow_id: "demo_flow",
+        run_id: "wf-3",
+        step_id: "step_a",
+        step_index: 1,
+        total_steps: 1,
+        label: "First step",
+        attempt: 1,
+      },
+      100
+    );
+    state = reduceEvent(
+      state,
+      {
+        type: "workflow_step_ended",
+        workflow_id: "demo_flow",
+        run_id: "wf-3",
+        step_id: "step_a",
+        step_index: 1,
+        total_steps: 1,
+        duration_ms: 42,
+      },
+      110
+    );
+    state = reduceEvent(
+      state,
+      {
+        type: "workflow_step_started",
+        workflow_id: "demo_flow",
+        run_id: "wf-3",
+        step_id: "step_a",
+        step_index: 1,
+        total_steps: 1,
+        label: "regressed label",
+        attempt: 1,
+      },
+      120
+    );
+    const step = state.messages[0].workflowSteps?.[0];
+    expect(step?.status).toBe("ok");
+    expect(step?.duration_ms).toBe(42);
+    expect(step?.label).toBe("First step");
+    expect(step?.attempt).toBe(1);
+  });
+
+  it("rejects a duplicate workflow_step_failed and preserves error + policy", () => {
+    let state = freshState();
+    state = reduceEvent(
+      state,
+      {
+        type: "workflow_step_started",
+        workflow_id: "demo_flow",
+        run_id: "wf-4",
+        step_id: "step_a",
+        step_index: 1,
+        total_steps: 1,
+        attempt: 1,
+      },
+      100
+    );
+    state = reduceEvent(
+      state,
+      {
+        type: "workflow_step_failed",
+        workflow_id: "demo_flow",
+        run_id: "wf-4",
+        step_id: "step_a",
+        step_index: 1,
+        total_steps: 1,
+        duration_ms: 7,
+        error: "original failure",
+        failure_policy: "fail_workflow",
+        attempt: 1,
+      },
+      110
+    );
+    state = reduceEvent(
+      state,
+      {
+        type: "workflow_step_failed",
+        workflow_id: "demo_flow",
+        run_id: "wf-4",
+        step_id: "step_a",
+        step_index: 1,
+        total_steps: 1,
+        duration_ms: 999,
+        error: "replayed failure",
+        failure_policy: "continue_with_warning",
+        attempt: 1,
+      },
+      120
+    );
+    const step = state.messages[0].workflowSteps?.[0];
+    expect(step?.status).toBe("failed");
+    expect(step?.error).toBe("original failure");
+    expect(step?.failure_policy).toBe("fail_workflow");
+    expect(step?.duration_ms).toBe(7);
+  });
+
+  it("rejects a late workflow_step_ended after failed", () => {
+    let state = freshState();
+    state = reduceEvent(
+      state,
+      {
+        type: "workflow_step_started",
+        workflow_id: "demo_flow",
+        run_id: "wf-5",
+        step_id: "step_a",
+        step_index: 1,
+        total_steps: 1,
+        attempt: 1,
+      },
+      100
+    );
+    state = reduceEvent(
+      state,
+      {
+        type: "workflow_step_failed",
+        workflow_id: "demo_flow",
+        run_id: "wf-5",
+        step_id: "step_a",
+        step_index: 1,
+        total_steps: 1,
+        duration_ms: 7,
+        error: "boom",
+        failure_policy: "fail_workflow",
+        attempt: 1,
+      },
+      110
+    );
+    state = reduceEvent(
+      state,
+      {
+        type: "workflow_step_ended",
+        workflow_id: "demo_flow",
+        run_id: "wf-5",
+        step_id: "step_a",
+        step_index: 1,
+        total_steps: 1,
+        duration_ms: 999,
+      },
+      120
+    );
+    const step = state.messages[0].workflowSteps?.[0];
+    expect(step?.status).toBe("failed");
+    expect(step?.error).toBe("boom");
+    expect(step?.duration_ms).toBe(7);
+  });
+
+  it("allows a retry (ok → running) when the attempt number increases", () => {
+    let state = freshState();
+    state = reduceEvent(
+      state,
+      {
+        type: "workflow_step_started",
+        workflow_id: "demo_flow",
+        run_id: "wf-6",
+        step_id: "step_a",
+        step_index: 1,
+        total_steps: 1,
+        attempt: 1,
+      },
+      100
+    );
+    state = reduceEvent(
+      state,
+      {
+        type: "workflow_step_failed",
+        workflow_id: "demo_flow",
+        run_id: "wf-6",
+        step_id: "step_a",
+        step_index: 1,
+        total_steps: 1,
+        duration_ms: 5,
+        error: "transient",
+        failure_policy: "fail_workflow",
+        attempt: 1,
+      },
+      110
+    );
+    state = reduceEvent(
+      state,
+      {
+        type: "workflow_step_started",
+        workflow_id: "demo_flow",
+        run_id: "wf-6",
+        step_id: "step_a",
+        step_index: 1,
+        total_steps: 1,
+        attempt: 2,
+      },
+      120
+    );
+    const step = state.messages[0].workflowSteps?.[0];
+    expect(step?.status).toBe("running");
+    expect(step?.attempt).toBe(2);
+  });
+
   it("returns state unchanged when no streaming message is active", () => {
     const state: StreamReducerState = {
       messages: [

--- a/frontend/src/lib/chat-stream-reducer.ts
+++ b/frontend/src/lib/chat-stream-reducer.ts
@@ -204,6 +204,18 @@ export function applyStreamEvent(
       }));
     case "new_response":
       return reduceNewResponseEvent(state, event, options);
+    case "prefix_invalidated":
+      return updateStreamingMessage(state, event, (message) => ({
+        ...message,
+        request_id: event.request_id ?? message.request_id,
+        blocks: appendSessionBlock(message.blocks, {
+          type: "prefix_invalidated",
+          session_id: event.session_id,
+          previous_fingerprint: event.previous_fingerprint,
+          current_fingerprint: event.current_fingerprint,
+          reason: event.reason,
+        }),
+      }));
     case "compaction_event":
       return {
         messages: state.messages,

--- a/frontend/src/lib/chat-stream-reducer.ts
+++ b/frontend/src/lib/chat-stream-reducer.ts
@@ -461,6 +461,30 @@ function workflowStepKey(runId: string, stepId: string): string {
   return `${runId}:${stepId}`;
 }
 
+function findWorkflowStep(
+  steps: WorkflowStepState[] | undefined,
+  runId: string,
+  stepId: string
+): WorkflowStepState | undefined {
+  const key = workflowStepKey(runId, stepId);
+  return (steps ?? []).find(
+    (entry) => workflowStepKey(entry.run_id, entry.step_id) === key
+  );
+}
+
+// Legal transitions: undefined → running/ok/failed, running → running/ok/failed.
+// Terminal states (ok/failed) are sticky so that a late or duplicate event cannot
+// regress an already-finished step. A new attempt number (retry) is the only way
+// to move out of a terminal state.
+function isValidWorkflowStepTransition(
+  existing: WorkflowStepState | undefined,
+  incomingAttempt: number
+): boolean {
+  if (!existing) return true;
+  if (incomingAttempt > existing.attempt) return true;
+  return existing.status === "running";
+}
+
 function upsertWorkflowStep(
   steps: WorkflowStepState[] | undefined,
   next: WorkflowStepState
@@ -482,6 +506,11 @@ function applyWorkflowStepStarted(
   steps: WorkflowStepState[] | undefined,
   event: ChatStreamWorkflowStepStartedEvent
 ): WorkflowStepState[] {
+  const existing = findWorkflowStep(steps, event.run_id, event.step_id);
+  const attempt = event.attempt ?? 1;
+  if (!isValidWorkflowStepTransition(existing, attempt)) {
+    return steps ?? [];
+  }
   return upsertWorkflowStep(steps, {
     workflow_id: event.workflow_id,
     run_id: event.run_id,
@@ -490,7 +519,7 @@ function applyWorkflowStepStarted(
     total_steps: event.total_steps,
     status: "running",
     label: event.label ?? undefined,
-    attempt: event.attempt ?? 1,
+    attempt,
   });
 }
 
@@ -498,11 +527,12 @@ function applyWorkflowStepEnded(
   steps: WorkflowStepState[] | undefined,
   event: ChatStreamWorkflowStepEndedEvent
 ): WorkflowStepState[] {
-  const existing = (steps ?? []).find(
-    (entry) =>
-      workflowStepKey(entry.run_id, entry.step_id) ===
-      workflowStepKey(event.run_id, event.step_id)
-  );
+  const existing = findWorkflowStep(steps, event.run_id, event.step_id);
+  // `workflow_step_ended` carries no attempt field, so a duplicate/late `ended`
+  // against a terminal step is always treated as a regression and rejected.
+  if (existing && existing.status !== "running") {
+    return steps ?? [];
+  }
   return upsertWorkflowStep(steps, {
     workflow_id: event.workflow_id,
     run_id: event.run_id,
@@ -520,11 +550,11 @@ function applyWorkflowStepFailed(
   steps: WorkflowStepState[] | undefined,
   event: ChatStreamWorkflowStepFailedEvent
 ): WorkflowStepState[] {
-  const existing = (steps ?? []).find(
-    (entry) =>
-      workflowStepKey(entry.run_id, entry.step_id) ===
-      workflowStepKey(event.run_id, event.step_id)
-  );
+  const existing = findWorkflowStep(steps, event.run_id, event.step_id);
+  const attempt = event.attempt ?? existing?.attempt ?? 1;
+  if (!isValidWorkflowStepTransition(existing, attempt)) {
+    return steps ?? [];
+  }
   return upsertWorkflowStep(steps, {
     workflow_id: event.workflow_id,
     run_id: event.run_id,
@@ -533,7 +563,7 @@ function applyWorkflowStepFailed(
     total_steps: event.total_steps,
     status: "failed",
     label: existing?.label,
-    attempt: event.attempt ?? existing?.attempt ?? 1,
+    attempt,
     duration_ms: event.duration_ms,
     error: event.error,
     failure_policy: event.failure_policy,

--- a/frontend/src/lib/raw-file-popup.ts
+++ b/frontend/src/lib/raw-file-popup.ts
@@ -58,7 +58,9 @@ function renderAuthenticatedRawSourceView(
     })
   );
   const cleanup = () => URL.revokeObjectURL(downloadUrl);
+  // `pagehide` covers browsers that skip `beforeunload` (iOS Safari, bfcache).
   popup.addEventListener("beforeunload", cleanup, { once: true });
+  popup.addEventListener("pagehide", cleanup, { once: true });
   window.setTimeout(cleanup, 5 * 60_000);
 
   const escapedPath = escapeHtml(path);
@@ -205,13 +207,28 @@ export const openRawFileInNewTab = async (path: string): Promise<void> => {
     }
 
     const { url } = await createRawFileObjectUrl(path);
-    window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    const revoke = () => URL.revokeObjectURL(url);
 
     if (popup && !popup.closed) {
       popup.location.replace(url);
+      // `popup.location.replace` navigates the blank popup to the blob URL,
+      // which would fire the popup's own `beforeunload`/`pagehide` before the
+      // blob loads and revoke the URL too early. Poll `popup.closed` instead
+      // so memory is reclaimed as soon as the user closes the popup, with
+      // the timeout kept only as a safety net.
+      const safetyTimer = window.setTimeout(revoke, 60_000);
+      const pollId = window.setInterval(() => {
+        if (popup.closed) {
+          window.clearInterval(pollId);
+          window.clearTimeout(safetyTimer);
+          revoke();
+        }
+      }, 1_000);
       return;
     }
+    // noopener fallback: no window reference, so rely on the timeout.
     window.open(url, "_blank", "noopener,noreferrer");
+    window.setTimeout(revoke, 60_000);
   } catch (error) {
     if (popup && !popup.closed) {
       writePopupMessage(

--- a/frontend/src/lib/runtime-events.generated.ts
+++ b/frontend/src/lib/runtime-events.generated.ts
@@ -160,6 +160,19 @@ export const NewResponseRuntimeEventSchema = z
     type: z.literal("new_response"),
   })
   .strict();
+/** Frozen prompt-cache prefix was replaced mid-session. */
+export const PrefixInvalidatedRuntimeEventSchema = z
+  .object({
+    current_fingerprint: z.string().nullish(),
+    event_index: z.number().int().min(1).nullish(),
+    previous_fingerprint: z.string().nullish(),
+    reason: z.string().nullish(),
+    request_id: z.string().nullish(),
+    schema_version: z.number().int().default(RUNTIME_EVENT_SCHEMA_VERSION),
+    session_id: z.string().nullish(),
+    type: z.literal("prefix_invalidated"),
+  })
+  .strict();
 export const CompactionRuntimeEventSchema = z
   .object({
     event_index: z.number().int().min(1).nullish(),
@@ -270,6 +283,7 @@ export const ChatStreamEventSchema = z.discriminatedUnion("type", [
   PlanUpdatedRuntimeEventSchema,
   VerificationResultRuntimeEventSchema,
   NewResponseRuntimeEventSchema,
+  PrefixInvalidatedRuntimeEventSchema,
   CompactionRuntimeEventSchema,
   WarningRuntimeEventSchema,
   DoneRuntimeEventSchema,
@@ -282,7 +296,7 @@ export const RuntimeEventSchema = ChatStreamEventSchema;
 export type ChatStreamEvent = z.infer<typeof ChatStreamEventSchema>;
 export type RuntimeEvent = ChatStreamEvent;
 
-export const RUNTIME_EVENT_TYPES = ["retrieval", "retrieval_error", "token", "tool_start", "tool_end", "tool_awaiting_approval", "tool_chunk", "plan_created", "plan_updated", "verification_result", "new_response", "compaction_event", "warning", "done", "error", "workflow_step_started", "workflow_step_ended", "workflow_step_failed"] as const;
+export const RUNTIME_EVENT_TYPES = ["retrieval", "retrieval_error", "token", "tool_start", "tool_end", "tool_awaiting_approval", "tool_chunk", "plan_created", "plan_updated", "verification_result", "new_response", "prefix_invalidated", "compaction_event", "warning", "done", "error", "workflow_step_started", "workflow_step_ended", "workflow_step_failed"] as const;
 export type RuntimeEventType = (typeof RUNTIME_EVENT_TYPES)[number];
 
 export const RUNTIME_EVENT_SCHEMAS: Record<RuntimeEventType, z.ZodTypeAny> = {
@@ -297,6 +311,7 @@ export const RUNTIME_EVENT_SCHEMAS: Record<RuntimeEventType, z.ZodTypeAny> = {
   plan_updated: PlanUpdatedRuntimeEventSchema,
   verification_result: VerificationResultRuntimeEventSchema,
   new_response: NewResponseRuntimeEventSchema,
+  prefix_invalidated: PrefixInvalidatedRuntimeEventSchema,
   compaction_event: CompactionRuntimeEventSchema,
   warning: WarningRuntimeEventSchema,
   done: DoneRuntimeEventSchema,

--- a/frontend/src/lib/session-catalog.ts
+++ b/frontend/src/lib/session-catalog.ts
@@ -121,29 +121,37 @@ export function useSessionCatalog(
   const messagesRef = useRef<Message[]>([]);
   const sessionContinuitySummariesRef = useRef<SessionContinuitySummary[]>([]);
 
-  useEffect(() => {
-    currentSessionIdRef.current = currentSessionId;
-  }, [currentSessionId]);
+  // Update the ref before dispatching the state update so callbacks that fire
+  // between this call and the next render commit observe the latest value.
+  const commitCurrentSessionId = useCallback((value: string | null) => {
+    currentSessionIdRef.current = value;
+    setCurrentSessionId(value);
+  }, []);
 
-  useEffect(() => {
-    messagesRef.current = messages;
-  }, [messages]);
+  const commitMessages = useCallback((value: Message[]) => {
+    messagesRef.current = value;
+    setMessages(value);
+  }, []);
 
-  useEffect(() => {
-    sessionContinuitySummariesRef.current = sessionContinuitySummaries;
-  }, [sessionContinuitySummaries]);
+  const commitSessionContinuitySummaries = useCallback(
+    (value: SessionContinuitySummary[]) => {
+      sessionContinuitySummariesRef.current = value;
+      setSessionContinuitySummaries(value);
+    },
+    []
+  );
 
   // React's useState setters are stable, so this object only needs to be built
   // once — cache it so dependent useCallback deps don't thrash on every render.
   const loadSessionSetters: SessionLoadSetters = useMemo(
     () => ({
-      setMessages,
-      setCurrentSessionId,
+      setMessages: commitMessages,
+      setCurrentSessionId: commitCurrentSessionId,
       setSessionHistoryStatus,
       setSessionHistoryError,
-      setSessionContinuitySummaries,
+      setSessionContinuitySummaries: commitSessionContinuitySummaries,
     }),
-    []
+    [commitCurrentSessionId, commitMessages, commitSessionContinuitySummaries]
   );
 
   // Reset session state when inspection access is lost.
@@ -162,16 +170,22 @@ export function useSessionCatalog(
     }
 
     setSessions([]);
-    setCurrentSessionId(null);
-    setMessages([]);
+    commitCurrentSessionId(null);
+    commitMessages([]);
     setSessionListStatus("idle");
     setSessionListError(null);
     setSessionHistoryStatus("idle");
     setSessionHistoryError(null);
-    setSessionContinuitySummaries([]);
+    commitSessionContinuitySummaries([]);
     setParseErrorCount(0);
     setRequestIdMismatchCount(0);
-  }, [accessByScope.inspection.status, hasLoadedApiAuthState]);
+  }, [
+    accessByScope.inspection.status,
+    commitCurrentSessionId,
+    commitMessages,
+    commitSessionContinuitySummaries,
+    hasLoadedApiAuthState,
+  ]);
 
   // Load session list and rehydrate current session once inspection access arrives.
   useEffect(() => {
@@ -190,7 +204,7 @@ export function useSessionCatalog(
       setSessionListError(null);
       setSessionHistoryStatus("idle");
       setSessionHistoryError(null);
-      setSessionContinuitySummaries([]);
+      commitSessionContinuitySummaries([]);
       return;
     }
 
@@ -214,11 +228,11 @@ export function useSessionCatalog(
             : (sessionList[0]?.id ?? null);
 
         if (!nextSessionId) {
-          setCurrentSessionId(null);
-          setMessages([]);
+          commitCurrentSessionId(null);
+          commitMessages([]);
           setSessionHistoryStatus("idle");
           setSessionHistoryError(null);
-          setSessionContinuitySummaries([]);
+          commitSessionContinuitySummaries([]);
           return;
         }
 
@@ -248,7 +262,7 @@ export function useSessionCatalog(
           ) {
             setSessionHistoryStatus("idle");
             setSessionHistoryError(null);
-            setSessionContinuitySummaries([]);
+            commitSessionContinuitySummaries([]);
           }
           promoteInspectionScopeError(error);
         }
@@ -262,6 +276,9 @@ export function useSessionCatalog(
     };
   }, [
     accessByScope.inspection.status,
+    commitCurrentSessionId,
+    commitMessages,
+    commitSessionContinuitySummaries,
     getSessionHistoryErrorMessage,
     getSessionListErrorMessage,
     hasInspectionAccess,
@@ -324,15 +341,21 @@ export function useSessionCatalog(
     setSessions((prev) => [session, ...prev]);
     setSessionListStatus("ready");
     setSessionListError(null);
-    setCurrentSessionId(session.id);
-    setMessages([]);
+    commitCurrentSessionId(session.id);
+    commitMessages([]);
     setSessionHistoryStatus("ready");
     setSessionHistoryError(null);
-    setSessionContinuitySummaries([]);
+    commitSessionContinuitySummaries([]);
     setParseErrorCount(0);
     setRequestIdMismatchCount(0);
     resetDraftAndInspector();
-  }, [hasExecutionAccess, resetDraftAndInspector]);
+  }, [
+    commitCurrentSessionId,
+    commitMessages,
+    commitSessionContinuitySummaries,
+    hasExecutionAccess,
+    resetDraftAndInspector,
+  ]);
 
   const selectSession = useCallback(
     async (id: string) => {
@@ -372,17 +395,24 @@ export function useSessionCatalog(
       await api.deleteSession(id);
       setSessions((prev) => prev.filter((s) => s.id !== id));
       if (id === currentSessionId) {
-        setCurrentSessionId(null);
-        setMessages([]);
+        commitCurrentSessionId(null);
+        commitMessages([]);
         setSessionHistoryStatus("idle");
         setSessionHistoryError(null);
-        setSessionContinuitySummaries([]);
+        commitSessionContinuitySummaries([]);
         setParseErrorCount(0);
-    setRequestIdMismatchCount(0);
+        setRequestIdMismatchCount(0);
         resetDraftAndInspector();
       }
     },
-    [currentSessionId, hasExecutionAccess, resetDraftAndInspector]
+    [
+      commitCurrentSessionId,
+      commitMessages,
+      commitSessionContinuitySummaries,
+      currentSessionId,
+      hasExecutionAccess,
+      resetDraftAndInspector,
+    ]
   );
 
   const applySessionTitle = useCallback((id: string, title: string) => {
@@ -422,15 +452,14 @@ export function useSessionCatalog(
         }
 
         const syncedMessages = historyToMessages(history);
-        messagesRef.current = syncedMessages;
-        setMessages(syncedMessages);
+        commitMessages(syncedMessages);
         setSessionHistoryStatus("ready");
         setSessionHistoryError(null);
       } catch {
         // Keep finished local transcript visible if reconciliation fails.
       }
     },
-    [hasInspectionAccess]
+    [commitMessages, hasInspectionAccess]
   );
 
   const finalizeCompletedSession = useCallback(
@@ -468,7 +497,7 @@ export function useSessionCatalog(
         setSessions((prev) => [session, ...prev]);
         setSessionListStatus("ready");
         setSessionListError(null);
-        setCurrentSessionId(session.id);
+        commitCurrentSessionId(session.id);
         setSessionHistoryStatus("ready");
         setSessionHistoryError(null);
         sessionId = session.id;
@@ -496,7 +525,7 @@ export function useSessionCatalog(
           userStoppedStreamRef,
         },
         callbacks: {
-          setMessages,
+          setMessages: commitMessages,
           setIsStreaming,
           onTurnComplete: (messageCount) => {
             void finalizeCompletedSession(
@@ -521,6 +550,8 @@ export function useSessionCatalog(
       });
     },
     [
+      commitCurrentSessionId,
+      commitMessages,
       currentSessionId,
       finalizeCompletedSession,
       hasExecutionAccess,

--- a/frontend/src/lib/session-catalog.ts
+++ b/frontend/src/lib/session-catalog.ts
@@ -459,6 +459,15 @@ export function useSessionCatalog(
   const sendMessage = useCallback(
     async (content: string, options?: SendMessageOptions) => {
       if (isStreaming || !hasExecutionAccess) return;
+      // `isStreaming` state can trail the refs under rapid send/stop/send,
+      // so assert the prior turn has fully released its refs before we
+      // overwrite the AbortController on a new turn.
+      if (
+        streamingIdRef.current !== null ||
+        streamAbortControllerRef.current !== null
+      ) {
+        return;
+      }
 
       let sessionId = currentSessionId;
       const hadNoMessages = messagesRef.current.length === 0;

--- a/frontend/src/lib/session-catalog.ts
+++ b/frontend/src/lib/session-catalog.ts
@@ -350,7 +350,7 @@ export function useSessionCatalog(
           getSessionHistoryErrorMessage
         );
         setParseErrorCount(0);
-    setRequestIdMismatchCount(0);
+        setRequestIdMismatchCount(0);
         resetDraftAndInspector();
       } catch (error) {
         promoteInspectionScopeError(error);
@@ -378,7 +378,7 @@ export function useSessionCatalog(
         setSessionHistoryError(null);
         setSessionContinuitySummaries([]);
         setParseErrorCount(0);
-    setRequestIdMismatchCount(0);
+        setRequestIdMismatchCount(0);
         resetDraftAndInspector();
       }
     },

--- a/frontend/src/lib/types.generated.ts
+++ b/frontend/src/lib/types.generated.ts
@@ -170,6 +170,17 @@ export interface ChatStreamPlanUpdatedEvent {
   tool_trace?: JsonObject[];
   type: "plan_updated";
 }
+/** Frozen prompt-cache prefix was replaced mid-session. */
+export interface ChatStreamPrefixInvalidatedEvent {
+  current_fingerprint?: string;
+  event_index?: number;
+  previous_fingerprint?: string;
+  reason?: string;
+  request_id?: string;
+  schema_version?: number;
+  session_id?: string;
+  type: "prefix_invalidated";
+}
 /** Non-fatal signal that a RAG retrieval attempt raised. */
 export interface ChatStreamRetrievalErrorEvent {
   error_type: string;
@@ -326,6 +337,7 @@ export type ChatStreamEventDTO =
   | ChatStreamPlanUpdatedEvent
   | ChatStreamVerificationResultEvent
   | ChatStreamNewResponseEvent
+  | ChatStreamPrefixInvalidatedEvent
   | ChatStreamCompactionEvent
   | WarningRuntimeEvent
   | ChatStreamDoneEvent

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -31,6 +31,7 @@ export type {
   ChatStreamPlanUpdatedEvent,
   ChatStreamVerificationResultEvent,
   ChatStreamNewResponseEvent,
+  ChatStreamPrefixInvalidatedEvent,
   ChatStreamCompactionEvent,
   ChatStreamDoneEvent,
   ChatStreamErrorEvent,
@@ -58,6 +59,7 @@ import type {
   ChatStreamPlanUpdatedEvent,
   ChatStreamVerificationResultEvent,
   ChatStreamNewResponseEvent,
+  ChatStreamPrefixInvalidatedEvent,
   ChatStreamCompactionEvent,
   ChatStreamDoneEvent,
   ChatStreamErrorEvent,
@@ -207,6 +209,20 @@ export interface SessionWarningBlock {
   review_path?: string;
 }
 
+/**
+ * Transport-only block surfaced when the backend replaces a session's frozen
+ * prompt-cache prefix mid-session. Not persisted in session JSON — it only
+ * lives on the streaming assistant message so the UI can render a pill
+ * explaining that provider prompt caching was dropped for this turn.
+ */
+export interface SessionPrefixInvalidatedBlock {
+  type: "prefix_invalidated";
+  session_id?: string;
+  previous_fingerprint?: string;
+  current_fingerprint?: string;
+  reason?: string;
+}
+
 export type SessionContentBlock =
   | SessionTextBlock
   | SessionToolUseBlock
@@ -216,7 +232,8 @@ export type SessionContentBlock =
   | SessionPlanBlock
   | SessionVerificationBlock
   | SessionApprovalGateBlock
-  | SessionWarningBlock;
+  | SessionWarningBlock
+  | SessionPrefixInvalidatedBlock;
 
 export interface ToolCall {
   tool: string;
@@ -280,6 +297,7 @@ export type ChatStreamEvent =
   | ChatStreamPlanUpdatedEvent
   | ChatStreamVerificationResultEvent
   | ChatStreamNewResponseEvent
+  | ChatStreamPrefixInvalidatedEvent
   | ChatStreamCompactionEvent
   | ChatStreamWarningEvent
   | ChatStreamDoneEvent

--- a/frontend/src/test/session-catalog-sendMessage-race.test.tsx
+++ b/frontend/src/test/session-catalog-sendMessage-race.test.tsx
@@ -1,0 +1,127 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSessionCatalog } from "@/lib/session-catalog";
+import type { AccessScope, AccessScopeState } from "@/lib/types";
+
+const runChatTurnMock = vi.fn();
+
+vi.mock("@/lib/chat-turn-runner", () => ({
+  runChatTurn: (...args: unknown[]) => runChatTurnMock(...args),
+  stopChatTurn: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    listSessions: vi.fn(async () => []),
+    createSession: vi.fn(async () => ({
+      id: "session-race",
+      title: "New Chat",
+      updated_at: 0,
+      message_count: 0,
+    })),
+    generateSessionTitle: vi.fn(async () => ({
+      session_id: "session-race",
+      title: "t",
+    })),
+    getHistory: vi.fn(async () => []),
+  };
+});
+
+function grantedScope(scope: AccessScope): AccessScopeState {
+  return {
+    scope,
+    status: "granted",
+    authorizationMode: "loopback",
+    hasToken: false,
+    detail: "",
+  };
+}
+
+function buildHookParams() {
+  return {
+    hasLoadedApiAuthState: true,
+    accessByScope: {
+      inspection: grantedScope("inspection"),
+      execution: grantedScope("execution"),
+      admin: grantedScope("admin"),
+    } as Record<AccessScope, AccessScopeState>,
+    hasInspectionAccess: true,
+    hasExecutionAccess: true,
+    promoteInspectionScopeError: vi.fn(),
+    getSessionListErrorMessage: (_error: unknown) => "list-error",
+    getSessionHistoryErrorMessage: (_error: unknown) => "history-error",
+    resetDraftAndInspector: vi.fn(),
+  };
+}
+
+describe("useSessionCatalog sendMessage — concurrent send guard", () => {
+  beforeEach(() => {
+    runChatTurnMock.mockReset();
+  });
+
+  it("bails out on a second sendMessage while refs from the first turn are still populated", async () => {
+    // Mirror what the real runChatTurn does synchronously before its await
+    // boundary: populate the refs the guard now inspects. Then hang forever
+    // so the refs stay dirty for the rest of the test.
+    runChatTurnMock.mockImplementation(async ({ refs }) => {
+      refs.streamingIdRef.current = "assistant-1";
+      refs.streamAbortControllerRef.current = new AbortController();
+      refs.userStoppedStreamRef.current = false;
+      await new Promise<void>(() => {});
+    });
+
+    const { result } = renderHook(() => useSessionCatalog(buildHookParams()));
+
+    await waitFor(() => {
+      expect(result.current.sessionListStatus).toBe("ready");
+    });
+
+    // Fire both calls inside the same synchronous tick: the first claims the
+    // refs; the second observes them still non-null and must bail, even
+    // though `isStreaming` in the useCallback closure is still false (no
+    // re-render has committed yet).
+    await act(async () => {
+      void result.current.sendMessage("first");
+      void result.current.sendMessage("second");
+      // Let microtasks drain so both calls reach the guard.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(runChatTurnMock).toHaveBeenCalledTimes(1);
+    expect(runChatTurnMock.mock.calls[0][0].content).toBe("first");
+  });
+
+  it("allows a subsequent sendMessage once the prior turn's refs are cleared", async () => {
+    const turns: Array<{ content: string }> = [];
+    runChatTurnMock.mockImplementation(async ({ content, refs }) => {
+      turns.push({ content });
+      refs.streamingIdRef.current = `assistant-${turns.length}`;
+      refs.streamAbortControllerRef.current = new AbortController();
+      refs.userStoppedStreamRef.current = false;
+      // Simulate a clean finish: reducer would null streamingIdRef on `done`,
+      // and the finally block of real runChatTurn nulls the controller.
+      refs.streamingIdRef.current = null;
+      refs.streamAbortControllerRef.current = null;
+    });
+
+    const { result } = renderHook(() => useSessionCatalog(buildHookParams()));
+
+    await waitFor(() => {
+      expect(result.current.sessionListStatus).toBe("ready");
+    });
+
+    await act(async () => {
+      await result.current.sendMessage("first");
+    });
+    await act(async () => {
+      await result.current.sendMessage("second");
+    });
+
+    expect(runChatTurnMock).toHaveBeenCalledTimes(2);
+    expect(turns.map((t) => t.content)).toEqual(["first", "second"]);
+  });
+});

--- a/scripts/codegen-types.ts
+++ b/scripts/codegen-types.ts
@@ -105,6 +105,7 @@ const EVENT_NAME_MAP: Record<string, string> = {
   PlanUpdatedRuntimeEvent: "ChatStreamPlanUpdatedEvent",
   VerificationResultRuntimeEvent: "ChatStreamVerificationResultEvent",
   NewResponseRuntimeEvent: "ChatStreamNewResponseEvent",
+  PrefixInvalidatedRuntimeEvent: "ChatStreamPrefixInvalidatedEvent",
   CompactionRuntimeEvent: "ChatStreamCompactionEvent",
   DoneRuntimeEvent: "ChatStreamDoneEvent",
   ErrorRuntimeEvent: "ChatStreamErrorEvent",


### PR DESCRIPTION
This PR implements two major features: argument-scoped tool approvals and prompt-cache prefix invalidation signaling.

## Summary

Extends the approval system to track tool invocations by both tool name and argument hash, enabling reviewers to approve/deny specific tool calls rather than all invocations of a tool. Also adds infrastructure to detect and signal when the frozen prompt-cache prefix becomes stale mid-session due to workspace or skill changes.

## Key Changes

**Approval System Enhancements:**
- `approval_store.py`: Refactored approval records to include `args_hash` field and added `compute_args_hash()` function for deterministic argument fingerprinting
- Records now keyed by `(tool_name, args_hash)` tuple with 5-minute TTL (`APPROVAL_TTL_SECONDS`)
- `tools/policy.py`: Updated `evaluate_pre_tool_policy()` to accept and use `args_hash` parameter for approval lookups
- `tools/policy_wrappers.py`: Integrated `compute_args_hash()` calls at tool invocation points
- Updated test fixtures and policy matrix tests to use `(tool_name, args_hash)` tuples

**Prompt-Cache Prefix Invalidation:**
- `graph/session/session_store.py`: Added `FrozenPrefixRegistration` dataclass to track invalidation state and previous fingerprint
- `SessionManager.freeze_session_prefix()` now returns registration object with `invalidated` flag when prefix diverges
- `runtime/events.py`: New `PrefixInvalidatedRuntimeEvent` emitted when cached prefix becomes stale
- `graph/agent.py`: Re-fingerprints stable prefix every turn and emits invalidation event on drift
- Frontend receives and renders prefix invalidation as a session block type

**Artifact Provenance Signing:**
- `artifacts/provenance.py`: Added HMAC-SHA256 signing for provenance bundles with `sign_provenance_payload()` and `verify_provenance_bundle()`
- Canonical JSON serialization ensures order-independent signature verification
- New `ProvenanceSignatureError` exception for signing failures

**Streaming & Tool Output Hardening:**
- `runtime/query_engine.py`: Added `_ACLOSE_TIMEOUT_S` bounded timeout for agent cleanup to prevent indefinite hangs when tools swallow `CancelledError`
- `api/files.py`: Explicit `text/plain; charset=utf-8` content-type and `X-Content-Type-Options: nosniff` for `.txt` tool-output overflow files
- `tools/contracts.py`: Added `partial_output` field to preserve stdout/stderr on tool errors

**Frontend Updates:**
- `chat-stream-reducer.ts`: Handle `prefix_invalidated` event type and append to message blocks
- `turn-activity-feed.helpers.ts`: Added stable `id` fields to feed descriptors for React key stability
- `session-catalog.ts`: Refactored state commit callbacks to update refs before dispatching state to prevent race conditions in concurrent `sendMessage` calls
- New test coverage for concurrent send guards and reader lock failure handling

**Session Index & Validation:**
- `session_index.py`: Added checksum validation to detect index corruption
- `session_store.py`: Frozen prefix drift detection with fingerprint comparison
- Expired approval records automatically dropped on load

## Notable Implementation Details

- Argument hashing uses SHA256 of canonical JSON representation for deterministic, order-independent fingerprinting
- Approval TTL prevents stale approvals from being silently reused across turns
- Prefix invalidation uses fingerprint comparison rather than sticky-first approach, allowing workspace/skill updates to take effect immediately
- Bounded async stream timeout prevents tool cleanup from blocking turn completion
- Feed descriptors now carry stable IDs derived from upstream identifiers (run_id, block index, step_id) for proper React reconciliation

https://claude.ai/code/session_011SZuhtwTBQ6aoUCYWgmeNW