### PR TITLE
auto: #266 Add retry backoff/limit for failed SSE streams

### DIFF
--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ArrowRight, MessageSquarePlus, RefreshCw, ShieldAlert } from "lucide-react";
 import SurfaceState from "@/components/layout/SurfaceState";
 import { useApp } from "@/lib/store";
+import { RETRY_MAX_ATTEMPTS } from "@/lib/retry-backoff";
 import ChatInput from "./ChatInput";
 import SessionHistorySummary from "@/components/session/SessionHistorySummary";
 
@@ -99,8 +100,41 @@ export default function ChatPanel() {
     await sendMessage(text);
   };
 
+  // Re-render once per second while a cooldown window is active so the
+  // remaining-wait label stays current and the button re-enables on schedule.
+  // Without this, the disabled state would only flip when something else in
+  // the tree triggered a render.
+  const [cooldownNow, setCooldownNow] = useState(() => Date.now());
+  const cooldownTarget = lastFailedTurn?.nextAllowedRetryAt ?? 0;
+  const isCooldownActive =
+    !!lastFailedTurn &&
+    !lastFailedTurn.reachedCap &&
+    cooldownTarget > cooldownNow &&
+    Number.isFinite(cooldownTarget);
+  useEffect(() => {
+    if (!isCooldownActive) return;
+    const handle = window.setInterval(() => {
+      setCooldownNow(Date.now());
+    }, 250);
+    return () => window.clearInterval(handle);
+  }, [isCooldownActive]);
+
+  const cooldownRemainingMs = isCooldownActive
+    ? Math.max(0, cooldownTarget - cooldownNow)
+    : 0;
+  const cooldownRemainingSeconds = Math.ceil(cooldownRemainingMs / 1000);
+  const reachedRetryCap = !!lastFailedTurn?.reachedCap;
+  const retryDisabled = isStreaming || isCooldownActive || reachedRetryCap;
+
   const handleRetryFailedTurn = useCallback(() => {
     if (!lastFailedTurn || isStreaming) return;
+    if (lastFailedTurn.reachedCap) return;
+    if (
+      Number.isFinite(lastFailedTurn.nextAllowedRetryAt) &&
+      Date.now() < lastFailedTurn.nextAllowedRetryAt
+    ) {
+      return;
+    }
     void sendMessage(lastFailedTurn.content, {
       requestId: lastFailedTurn.requestId,
     });
@@ -199,17 +233,31 @@ export default function ChatPanel() {
                   compact
                   tone="error"
                   eyebrow="Turn Failed"
-                  title="Turn failed — retry"
-                  description={
-                    lastFailedTurn.requestId
-                      ? `The last turn did not complete. Retry re-issues it with request ${lastFailedTurn.requestId}.`
-                      : "The last turn did not complete. Retry re-issues it with the same request id."
+                  title={
+                    reachedRetryCap
+                      ? "Turn failed — retry limit reached"
+                      : "Turn failed — retry"
                   }
+                  description={buildRetryBannerDescription({
+                    requestId: lastFailedTurn.requestId,
+                    attemptCount: lastFailedTurn.attemptCount,
+                    reachedCap: reachedRetryCap,
+                    cooldownRemainingSeconds: isCooldownActive
+                      ? cooldownRemainingSeconds
+                      : 0,
+                  })}
                   actions={
                     <div className="flex flex-wrap gap-2">
-                      <InlineActionButton onClick={handleRetryFailedTurn}>
+                      <InlineActionButton
+                        onClick={handleRetryFailedTurn}
+                        disabled={retryDisabled}
+                      >
                         <RefreshCw size={12} />
-                        Retry turn
+                        {isCooldownActive
+                          ? `Retry in ${cooldownRemainingSeconds}s`
+                          : reachedRetryCap
+                            ? "No more retries"
+                            : "Retry turn"}
                       </InlineActionButton>
                       <InlineActionButton onClick={clearLastFailedTurn}>
                         Dismiss
@@ -241,19 +289,46 @@ export default function ChatPanel() {
 function InlineActionButton({
   children,
   onClick,
+  disabled = false,
 }: {
   children: React.ReactNode;
   onClick: () => void;
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-2 rounded-full border border-[var(--shell-border)] bg-white/92 px-3 py-1.5 text-[11px] font-medium text-slate-600 transition-colors hover:bg-[var(--panel-soft)] hover:text-slate-800"
+      disabled={disabled}
+      className="inline-flex items-center gap-2 rounded-full border border-[var(--shell-border)] bg-white/92 px-3 py-1.5 text-[11px] font-medium text-slate-600 transition-colors hover:bg-[var(--panel-soft)] hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-white/92 disabled:hover:text-slate-600"
     >
       {children}
     </button>
   );
+}
+
+function buildRetryBannerDescription({
+  requestId,
+  attemptCount,
+  reachedCap,
+  cooldownRemainingSeconds,
+}: {
+  requestId: string | undefined;
+  attemptCount: number;
+  reachedCap: boolean;
+  cooldownRemainingSeconds: number;
+}): string {
+  const reqSuffix = requestId
+    ? ` Retry re-issues it with request ${requestId}.`
+    : " Retry re-issues it with the same request id.";
+
+  if (reachedCap) {
+    return `The last turn failed ${attemptCount} time${attemptCount === 1 ? "" : "s"}; the retry limit (${RETRY_MAX_ATTEMPTS}) has been reached. Dismiss this banner and send a fresh message to try again.`;
+  }
+  if (cooldownRemainingSeconds > 0) {
+    return `The last turn did not complete (attempt ${attemptCount} of ${RETRY_MAX_ATTEMPTS}). Cooling down ${cooldownRemainingSeconds}s before another retry is allowed.${reqSuffix}`;
+  }
+  return `The last turn did not complete (attempt ${attemptCount} of ${RETRY_MAX_ATTEMPTS}).${reqSuffix}`;
 }
 
 function EmptyState({

--- a/frontend/src/lib/retry-backoff.ts
+++ b/frontend/src/lib/retry-backoff.ts
@@ -1,0 +1,50 @@
+/**
+ * Backoff/cap policy for the user-triggered "Retry turn" flow.
+ *
+ * The retry button on a failed SSE stream re-issues the original turn. Without
+ * a cap or cooldown a user can spam-click it (or a tight failure loop can
+ * stampede the backend). We bound that with a small exponential schedule plus
+ * a hard attempt limit; the math lives here so it can be unit-tested in
+ * isolation from React state.
+ */
+
+export const RETRY_BASE_DELAY_MS = 1000;
+export const RETRY_FACTOR = 2;
+export const RETRY_MAX_DELAY_MS = 30_000;
+export const RETRY_MAX_ATTEMPTS = 5;
+const RETRY_JITTER_FRACTION = 0.2;
+
+export interface ComputeRetryBackoffOptions {
+  /** Override Math.random() for deterministic tests. Must return [0, 1). */
+  random?: () => number;
+}
+
+/**
+ * Returns the cooldown (ms) the UI should wait after `attemptCount` failed
+ * attempts before allowing another retry. `attemptCount` is the number of
+ * failures observed so far (1 after the first failure). The result is bounded
+ * by RETRY_MAX_DELAY_MS and includes additive jitter in [0, 20%) to spread
+ * concurrent retries across clients.
+ */
+export function computeRetryBackoffMs(
+  attemptCount: number,
+  options: ComputeRetryBackoffOptions = {}
+): number {
+  if (!Number.isFinite(attemptCount) || attemptCount <= 0) {
+    return 0;
+  }
+  const random = options.random ?? Math.random;
+  const exponent = Math.max(0, Math.floor(attemptCount) - 1);
+  const base = RETRY_BASE_DELAY_MS * Math.pow(RETRY_FACTOR, exponent);
+  const jitter = random() * RETRY_JITTER_FRACTION;
+  const withJitter = base * (1 + jitter);
+  return Math.min(RETRY_MAX_DELAY_MS, Math.round(withJitter));
+}
+
+/**
+ * True when the user has hit the configured max-attempts ceiling and we
+ * should refuse further retries from the inline error UI.
+ */
+export function hasReachedRetryCap(attemptCount: number): boolean {
+  return Number.isFinite(attemptCount) && attemptCount >= RETRY_MAX_ATTEMPTS;
+}

--- a/frontend/src/lib/session-catalog.ts
+++ b/frontend/src/lib/session-catalog.ts
@@ -3,6 +3,10 @@ import { isAccessGranted } from "./access-control";
 import * as api from "./api";
 import { runChatTurn, stopChatTurn } from "./chat-turn-runner";
 import {
+  computeRetryBackoffMs,
+  hasReachedRetryCap,
+} from "./retry-backoff";
+import {
   historyToMessages,
   loadSession,
   type SessionHistoryStatus,
@@ -43,6 +47,23 @@ export interface SendMessageOptions {
 export interface FailedTurnState {
   content: string;
   requestId?: string;
+  /**
+   * Number of failures recorded for this retry chain (1 after the first
+   * failure, incremented each time `onTurnError` fires for a retry that
+   * carries the same `requestId`). Resets implicitly when the user dismisses
+   * the failure or the next turn completes successfully.
+   */
+  attemptCount: number;
+  /**
+   * Epoch milliseconds before which the Retry-turn button must remain
+   * disabled. Computed from `attemptCount` via `computeRetryBackoffMs`.
+   */
+  nextAllowedRetryAt: number;
+  /**
+   * True once `attemptCount` has hit the configured max. The UI must refuse
+   * any further retries; the user has to dismiss and start a fresh turn.
+   */
+  reachedCap: boolean;
 }
 
 export interface UseSessionCatalogResult {
@@ -120,6 +141,12 @@ export function useSessionCatalog(
   const currentSessionIdRef = useRef<string | null>(null);
   const messagesRef = useRef<Message[]>([]);
   const sessionContinuitySummariesRef = useRef<SessionContinuitySummary[]>([]);
+  // Mirror of `lastFailedTurn` so the in-flight `onTurnError` callback can
+  // read the prior attempt count without depending on stale closure capture.
+  // We need this because `sendMessage` clears `lastFailedTurn` early, before
+  // running the turn — without the ref, a retry's failure callback would
+  // always observe `null` and reset the counter to 1.
+  const lastFailedTurnRef = useRef<FailedTurnState | null>(null);
 
   useEffect(() => {
     currentSessionIdRef.current = currentSessionId;
@@ -132,6 +159,10 @@ export function useSessionCatalog(
   useEffect(() => {
     sessionContinuitySummariesRef.current = sessionContinuitySummaries;
   }, [sessionContinuitySummaries]);
+
+  useEffect(() => {
+    lastFailedTurnRef.current = lastFailedTurn;
+  }, [lastFailedTurn]);
 
   // React's useState setters are stable, so this object only needs to be built
   // once — cache it so dependent useCallback deps don't thrash on every render.
@@ -483,6 +514,20 @@ export function useSessionCatalog(
       }
 
       resetDraftAndInspector();
+
+      // Carry the prior attempt count forward only when this send is a retry
+      // of the same correlated request (i.e. the user clicked Retry turn).
+      // A fresh user message — which arrives without `options?.requestId`, or
+      // with a different one — starts a new retry chain at attempt 1.
+      const previousFailure = lastFailedTurnRef.current;
+      const isRetryOfPrevious =
+        previousFailure !== null &&
+        options?.requestId !== undefined &&
+        previousFailure.requestId === options.requestId;
+      const previousAttemptCount = isRetryOfPrevious
+        ? previousFailure.attemptCount
+        : 0;
+
       setLastFailedTurn(null);
 
       await runChatTurn({
@@ -506,9 +551,17 @@ export function useSessionCatalog(
             );
           },
           onTurnError: (failedRequestId) => {
+            const attemptCount = previousAttemptCount + 1;
+            const reachedCap = hasReachedRetryCap(attemptCount);
+            const nextAllowedRetryAt = reachedCap
+              ? Number.POSITIVE_INFINITY
+              : Date.now() + computeRetryBackoffMs(attemptCount);
             setLastFailedTurn({
               content,
               requestId: failedRequestId ?? options?.requestId,
+              attemptCount,
+              nextAllowedRetryAt,
+              reachedCap,
             });
           },
           onParseError: () => {

--- a/frontend/src/test/ChatPanel.retry.test.tsx
+++ b/frontend/src/test/ChatPanel.retry.test.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/store", () => ({
+  useApp: vi.fn(),
+}));
+
+vi.mock("@/components/chat/ChatInput", () => ({
+  default: () => <div data-testid="chat-input-stub" />,
+}));
+
+vi.mock("@/components/session/SessionHistorySummary", () => ({
+  default: () => <div data-testid="session-history-stub" />,
+}));
+
+import { useApp } from "@/lib/store";
+import ChatPanel from "@/components/chat/ChatPanel";
+import { RETRY_MAX_ATTEMPTS } from "@/lib/retry-backoff";
+import { makeMockAppValue } from "@/test/panel-fixtures";
+import type { FailedTurnState } from "@/lib/session-catalog";
+
+function findRetryButton(): HTMLButtonElement {
+  const buttons = screen.getAllByRole("button") as HTMLButtonElement[];
+  const match = buttons.find((b) =>
+    /Retry( turn| in | failed)|No more retries/i.test(b.textContent ?? "")
+  );
+  if (!match) {
+    throw new Error("Retry button not found in rendered ChatPanel");
+  }
+  return match;
+}
+
+describe("ChatPanel retry banner", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  function renderWithFailedTurn(failedTurn: FailedTurnState) {
+    const sendMessage = vi.fn(async () => {});
+    const clearLastFailedTurn = vi.fn();
+    vi.mocked(useApp).mockReturnValue(
+      makeMockAppValue({
+        lastFailedTurn: failedTurn,
+        sendMessage,
+        clearLastFailedTurn,
+      })
+    );
+    const result = render(<ChatPanel />);
+    return { sendMessage, clearLastFailedTurn, ...result };
+  }
+
+  it("disables the Retry button while the cooldown window is active", () => {
+    const now = Date.now();
+    renderWithFailedTurn({
+      content: "ping",
+      requestId: "req-1",
+      attemptCount: 1,
+      nextAllowedRetryAt: now + 5_000,
+      reachedCap: false,
+    });
+
+    const button = findRetryButton();
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toMatch(/Retry in \d+s/);
+  });
+
+  it("re-enables the Retry button once the cooldown elapses", () => {
+    const now = Date.now();
+    const { sendMessage } = renderWithFailedTurn({
+      content: "ping",
+      requestId: "req-1",
+      attemptCount: 1,
+      nextAllowedRetryAt: now + 1_000,
+      reachedCap: false,
+    });
+
+    expect(findRetryButton().disabled).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+
+    const button = findRetryButton();
+    expect(button.disabled).toBe(false);
+    expect(button.textContent).toMatch(/Retry turn/);
+
+    act(() => {
+      button.click();
+    });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith("ping", { requestId: "req-1" });
+  });
+
+  it("disables the Retry button and shows 'No more retries' once the cap is hit", () => {
+    const { sendMessage } = renderWithFailedTurn({
+      content: "ping",
+      requestId: "req-1",
+      attemptCount: RETRY_MAX_ATTEMPTS,
+      nextAllowedRetryAt: Number.POSITIVE_INFINITY,
+      reachedCap: true,
+    });
+
+    const button = findRetryButton();
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toMatch(/No more retries/);
+
+    act(() => {
+      button.click();
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the retry-limit copy in the banner description when capped", () => {
+    renderWithFailedTurn({
+      content: "ping",
+      requestId: "req-1",
+      attemptCount: RETRY_MAX_ATTEMPTS,
+      nextAllowedRetryAt: Number.POSITIVE_INFINITY,
+      reachedCap: true,
+    });
+
+    expect(
+      screen.getByText(
+        new RegExp(`retry limit \\(${RETRY_MAX_ATTEMPTS}\\) has been reached`, "i")
+      )
+    ).toBeTruthy();
+  });
+
+  it("triggers sendMessage with the original requestId on a fresh failure (no cooldown remaining)", () => {
+    const now = Date.now();
+    const { sendMessage } = renderWithFailedTurn({
+      content: "hello",
+      requestId: "req-7",
+      attemptCount: 1,
+      nextAllowedRetryAt: now - 1, // already past — no cooldown remaining
+      reachedCap: false,
+    });
+
+    const button = findRetryButton();
+    expect(button.disabled).toBe(false);
+
+    act(() => {
+      button.click();
+    });
+    expect(sendMessage).toHaveBeenCalledWith("hello", { requestId: "req-7" });
+  });
+});

--- a/frontend/src/test/retry-backoff.test.ts
+++ b/frontend/src/test/retry-backoff.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  RETRY_BASE_DELAY_MS,
+  RETRY_FACTOR,
+  RETRY_MAX_ATTEMPTS,
+  RETRY_MAX_DELAY_MS,
+  computeRetryBackoffMs,
+  hasReachedRetryCap,
+} from "@/lib/retry-backoff";
+
+describe("computeRetryBackoffMs", () => {
+  it("returns the base delay on the first failure with zero jitter", () => {
+    expect(computeRetryBackoffMs(1, { random: () => 0 })).toBe(
+      RETRY_BASE_DELAY_MS
+    );
+  });
+
+  it("doubles the delay with each subsequent failure (zero jitter)", () => {
+    const rand = () => 0;
+    expect(computeRetryBackoffMs(2, { random: rand })).toBe(
+      RETRY_BASE_DELAY_MS * RETRY_FACTOR
+    );
+    expect(computeRetryBackoffMs(3, { random: rand })).toBe(
+      RETRY_BASE_DELAY_MS * RETRY_FACTOR * RETRY_FACTOR
+    );
+    expect(computeRetryBackoffMs(4, { random: rand })).toBe(
+      RETRY_BASE_DELAY_MS * Math.pow(RETRY_FACTOR, 3)
+    );
+  });
+
+  it("applies up to ~20% jitter on top of the base delay", () => {
+    const result = computeRetryBackoffMs(1, { random: () => 0.999_999 });
+    expect(result).toBeGreaterThanOrEqual(RETRY_BASE_DELAY_MS);
+    expect(result).toBeLessThanOrEqual(Math.ceil(RETRY_BASE_DELAY_MS * 1.2));
+  });
+
+  it("clamps the delay to RETRY_MAX_DELAY_MS even with maximum jitter", () => {
+    // Attempt 10 would otherwise be 1000 * 2^9 = 512000ms.
+    expect(computeRetryBackoffMs(10, { random: () => 0.999_999 })).toBe(
+      RETRY_MAX_DELAY_MS
+    );
+  });
+
+  it("returns 0 for non-positive or non-finite attempt counts", () => {
+    const rand = () => 0.5;
+    expect(computeRetryBackoffMs(0, { random: rand })).toBe(0);
+    expect(computeRetryBackoffMs(-1, { random: rand })).toBe(0);
+    expect(computeRetryBackoffMs(Number.NaN, { random: rand })).toBe(0);
+    expect(
+      computeRetryBackoffMs(Number.POSITIVE_INFINITY, { random: rand })
+    ).toBe(0);
+  });
+
+  it("monotonically increases (or stays at the cap) as attempts grow with fixed jitter", () => {
+    const rand = () => 0.5;
+    let previous = -1;
+    for (let attempt = 1; attempt <= 12; attempt += 1) {
+      const value = computeRetryBackoffMs(attempt, { random: rand });
+      expect(value).toBeGreaterThanOrEqual(previous);
+      previous = value;
+    }
+  });
+});
+
+describe("hasReachedRetryCap", () => {
+  it("returns false until RETRY_MAX_ATTEMPTS attempts have been recorded", () => {
+    for (let attempt = 0; attempt < RETRY_MAX_ATTEMPTS; attempt += 1) {
+      expect(hasReachedRetryCap(attempt)).toBe(false);
+    }
+  });
+
+  it("returns true once RETRY_MAX_ATTEMPTS is reached", () => {
+    expect(hasReachedRetryCap(RETRY_MAX_ATTEMPTS)).toBe(true);
+    expect(hasReachedRetryCap(RETRY_MAX_ATTEMPTS + 1)).toBe(true);
+  });
+
+  it("treats non-finite attempt counts as below the cap", () => {
+    expect(hasReachedRetryCap(Number.NaN)).toBe(false);
+    expect(hasReachedRetryCap(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #266

Opened by the personal automation loop. Draft until human-reviewed.