### PR TITLE
auto: #270 Runtime-validate SessionHistoryMessage has content or blocks

### DIFF
--- a/frontend/src/lib/api-payload.ts
+++ b/frontend/src/lib/api-payload.ts
@@ -277,20 +277,45 @@ export function validateSessionHistory(
 ): SessionHistoryMessage[] {
   const history = expectArray(value, path, "the session history");
   history.forEach((message, index) => {
+    const label = `session history item ${index + 1}`;
     const record = expectObject(message, path, "the session history");
-    expectStringField(record, "role", path, `session history item ${index + 1}`);
-    if ("content" in record && typeof record.content !== "string") {
+    expectStringField(record, "role", path, label);
+
+    let hasContent = false;
+    if ("content" in record && record.content !== undefined) {
+      if (typeof record.content !== "string") {
+        throw createPayloadError(
+          path,
+          label,
+          'Expected "content" to be a string when present.'
+        );
+      }
+      hasContent = record.content.trim().length > 0;
+    }
+
+    let hasBlocks = false;
+    if ("blocks" in record && record.blocks !== undefined) {
+      validateSessionContentBlocks(record.blocks, path, label);
+      hasBlocks = (record.blocks as unknown[]).length > 0;
+    }
+
+    let hasToolCalls = false;
+    if ("tool_calls" in record && record.tool_calls !== undefined) {
+      const calls = expectArray(record.tool_calls, path, label);
+      hasToolCalls = calls.length > 0;
+    }
+
+    let hasRetrievals = false;
+    if ("retrievals" in record && record.retrievals !== undefined) {
+      const retrievals = expectArray(record.retrievals, path, label);
+      hasRetrievals = retrievals.length > 0;
+    }
+
+    if (!hasContent && !hasBlocks && !hasToolCalls && !hasRetrievals) {
       throw createPayloadError(
         path,
-        `session history item ${index + 1}`,
-        'Expected "content" to be a string when present.'
-      );
-    }
-    if ("blocks" in record) {
-      validateSessionContentBlocks(
-        record.blocks,
-        path,
-        `session history item ${index + 1}`
+        label,
+        'Expected "content" or "blocks" to provide message data; both were missing or empty.'
       );
     }
   });

--- a/frontend/src/test/api-payload.session-history.test.ts
+++ b/frontend/src/test/api-payload.session-history.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  ApiPayloadError,
+  isApiPayloadError,
+  validateSessionHistory,
+} from "@/lib/api-payload";
+
+const PATH = "/api/sessions/abc/history";
+
+function expectPayloadError(fn: () => unknown): ApiPayloadError {
+  try {
+    fn();
+  } catch (error) {
+    if (!isApiPayloadError(error)) {
+      throw new Error(
+        `Expected ApiPayloadError, got ${error instanceof Error ? error.name : typeof error}`
+      );
+    }
+    return error;
+  }
+  throw new Error("Expected validateSessionHistory to throw, but it returned.");
+}
+
+describe("validateSessionHistory", () => {
+  it("accepts user messages with non-empty content", () => {
+    const result = validateSessionHistory(
+      [{ role: "user", content: "Hello" }],
+      PATH
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]?.role).toBe("user");
+  });
+
+  it("accepts assistant messages whose payload is carried by blocks only", () => {
+    const result = validateSessionHistory(
+      [
+        {
+          role: "assistant",
+          blocks: [{ type: "text", text: "Reviewed the readiness checklist." }],
+        },
+      ],
+      PATH
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]?.blocks).toHaveLength(1);
+  });
+
+  it("accepts assistant messages whose payload is only tool_calls", () => {
+    const result = validateSessionHistory(
+      [
+        {
+          role: "assistant",
+          tool_calls: [
+            { tool: "read_file", input: "knowledge/x.md", output: "..." },
+          ],
+        },
+      ],
+      PATH
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it("accepts assistant messages whose payload is only retrievals", () => {
+    const result = validateSessionHistory(
+      [
+        {
+          role: "assistant",
+          retrievals: [
+            { source: "knowledge/x.md", score: 0.91, text: "..." },
+          ],
+        },
+      ],
+      PATH
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it("rejects messages missing both content and blocks (silent blank row)", () => {
+    const error = expectPayloadError(() =>
+      validateSessionHistory([{ role: "assistant" }], PATH)
+    );
+    expect(error.path).toBe(PATH);
+    expect(error.detail).toMatch(/content.*blocks/);
+    expect(error.message).toContain("session history");
+  });
+
+  it("rejects messages where content is empty/whitespace and blocks is empty", () => {
+    const error = expectPayloadError(() =>
+      validateSessionHistory(
+        [{ role: "assistant", content: "   ", blocks: [] }],
+        PATH
+      )
+    );
+    expect(error.detail).toMatch(/missing or empty/);
+  });
+
+  it("rejects messages where every supporting field is empty", () => {
+    const error = expectPayloadError(() =>
+      validateSessionHistory(
+        [
+          {
+            role: "assistant",
+            content: "",
+            blocks: [],
+            tool_calls: [],
+            retrievals: [],
+          },
+        ],
+        PATH
+      )
+    );
+    expect(error.detail).toMatch(/missing or empty/);
+  });
+
+  it("still rejects payloads where content is not a string when present", () => {
+    const error = expectPayloadError(() =>
+      validateSessionHistory(
+        [{ role: "assistant", content: 42, blocks: [{ type: "text", text: "ok" }] }],
+        PATH
+      )
+    );
+    expect(error.detail).toMatch(/"content" to be a string/);
+  });
+
+  it("rejects payloads whose blocks field has an invalid block shape", () => {
+    const error = expectPayloadError(() =>
+      validateSessionHistory(
+        [
+          {
+            role: "assistant",
+            blocks: [{ type: "tool_use", tool: "read_file" /* missing input */ }],
+          },
+        ],
+        PATH
+      )
+    );
+    expect(error.detail).toMatch(/"input"/);
+  });
+
+  it("identifies the offending row by index in the error label", () => {
+    const error = expectPayloadError(() =>
+      validateSessionHistory(
+        [
+          { role: "user", content: "hi" },
+          { role: "assistant" },
+        ],
+        PATH
+      )
+    );
+    expect(error.message).toContain("session history item 2");
+  });
+});


### PR DESCRIPTION
Closes #270

Opened by the personal automation loop. Draft until human-reviewed.